### PR TITLE
fix: resolve critical bugs breaking core app functionality

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # ============================================================
-# Libre Bird Platform — Docker Compose
+# Kestrel Platform — Docker Compose
 # Gateway (Node.js) + Brain (Python) + Hands (Python)
 # + PostgreSQL + Redis
 # ============================================================
@@ -124,7 +124,7 @@ services:
       context: ./packages/web
       dockerfile: Dockerfile
     ports:
-      - "5174:80"
+      - "5173:80"
     depends_on:
       - gateway
 

--- a/packages/brain/providers/cloud.py
+++ b/packages/brain/providers/cloud.py
@@ -294,11 +294,9 @@ class CloudProvider:
     def _list_anthropic_models(self) -> list[dict]:
         # Return hardcoded list as Anthropic doesn't have a simple list endpoint purely for models
         return [
-            {"id": "claude-3-opus-20240229", "name": "Claude 3 Opus", "context_window": "200k"},
-            {"id": "claude-3-sonnet-20240229", "name": "Claude 3 Sonnet", "context_window": "200k"},
-            {"id": "claude-3-haiku-20240307", "name": "Claude 3 Haiku", "context_window": "200k"},
-            {"id": "claude-3-5-sonnet-20240620", "name": "Claude 3.5 Sonnet", "context_window": "200k"},
-            {"id": "claude-3-5-haiku-20241022", "name": "Claude 3.5 Haiku", "context_window": "200k"},
+            {"id": "claude-opus-4-6", "name": "Claude Opus 4.6", "context_window": "200k"},
+            {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5", "context_window": "200k"},
+            {"id": "claude-haiku-4-5", "name": "Claude Haiku 4.5", "context_window": "200k"},
         ]
 
     async def _list_google_models(self, api_key: str) -> list[dict]:

--- a/packages/brain/server.py
+++ b/packages/brain/server.py
@@ -771,14 +771,14 @@ class BrainServicer:
             
             # Allow "smart" title generation:
             response_chunks = []
-            async for chunk in provider.stream_chat(
+            async for token in provider.stream(
                 messages=[{"role": "user", "content": prompt}],
-                model="default",
-                parameters={"temperature": 0.3, "max_tokens": 20}
+                model="",
+                temperature=0.3,
+                max_tokens=20,
             ):
-                 if chunk.get("type") == "content_delta":
-                     response_chunks.append(chunk["content_delta"])
-            
+                response_chunks.append(token)
+
             generated_title = "".join(response_chunks).strip().strip('"')
             
             # Update the title in DB

--- a/packages/shared/proto/brain.proto
+++ b/packages/shared/proto/brain.proto
@@ -210,6 +210,33 @@ message GetMessagesResponse {
   repeated MessageResponse messages = 1;
 }
 
+message UpdateConversationRequest {
+  string user_id = 1;
+  string workspace_id = 2;
+  string conversation_id = 3;
+  string title = 4;
+}
+
+message DeleteConversationRequest {
+  string user_id = 1;
+  string workspace_id = 2;
+  string conversation_id = 3;
+}
+
+message DeleteConversationResponse {
+  bool success = 1;
+}
+
+message GenerateTitleRequest {
+  string user_id = 1;
+  string workspace_id = 2;
+  string conversation_id = 3;
+}
+
+message GenerateTitleResponse {
+  string title = 1;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // Mobile / Sync
 // ═══════════════════════════════════════════════════════════════

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from './hooks/useAuth';
 import { LoginPage } from './components/Auth/LoginPage';
 import { Sidebar } from './components/Sidebar/Sidebar';
@@ -13,6 +13,7 @@ export default function App() {
     const [currentConversation, setCurrentConversation] = useState<Conversation | null>(null);
     const [initialMessages, setInitialMessages] = useState<Message[]>([]);
     const [showSettings, setShowSettings] = useState(false);
+    const autoCreateAttempted = useRef<string | null>(null);
 
     const { messages, streamingMessage, sendMessage, isConnected } = useChat(
         currentWorkspace?.id || null,
@@ -29,9 +30,10 @@ export default function App() {
             .catch(console.error);
     }, [currentWorkspace, currentConversation]);
 
-    // Auto-create conversation if none exists
+    // Auto-create conversation if none exists (only attempt once per workspace)
     useEffect(() => {
-        if (currentWorkspace && !currentConversation) {
+        if (currentWorkspace && !currentConversation && autoCreateAttempted.current !== currentWorkspace.id) {
+            autoCreateAttempted.current = currentWorkspace.id;
             conversations.create(currentWorkspace.id)
                 .then(conv => {
                     setCurrentConversation(conv);

--- a/packages/web/src/components/Chat/ChatView.tsx
+++ b/packages/web/src/components/Chat/ChatView.tsx
@@ -2,9 +2,9 @@ import { useState, useRef, useEffect, type FormEvent } from 'react';
 import type { Message } from '../../api/client';
 
 const PROVIDER_MODELS: Record<string, string[]> = {
-    google: ['gemini-2.0-flash', 'gemini-1.5-pro'],
-    openai: ['gpt-4o', 'gpt-4o-mini', 'o1', 'o3-mini'],
-    anthropic: ['claude-3-5-sonnet-20241022', 'claude-3-5-haiku-20241022'],
+    openai: ['gpt-5-mini', 'gpt-5', 'gpt-5.1', 'gpt-5.2', 'gpt-5-nano'],
+    anthropic: ['claude-haiku-4-5', 'claude-sonnet-4-5', 'claude-opus-4-6'],
+    google: ['gemini-3-flash', 'gemini-3-pro', 'gemini-2.5-flash', 'gemini-2.5-pro'],
     local: ['auto'],
 };
 

--- a/packages/web/src/components/Settings/ConfigureProviderModal.tsx
+++ b/packages/web/src/components/Settings/ConfigureProviderModal.tsx
@@ -100,9 +100,9 @@ export function ConfigureProviderModal({ workspaceId, providerKey, providerName,
 
     const getDefaultModel = (key: string) => {
         switch (key) {
-            case 'openai': return 'gpt-4o';
-            case 'anthropic': return 'claude-3-5-sonnet-20240620';
-            case 'google': return 'gemini-1.5-flash';
+            case 'openai': return 'gpt-5-mini';
+            case 'anthropic': return 'claude-haiku-4-5';
+            case 'google': return 'gemini-3-flash';
             case 'local': return 'llama-3-8b-instruct';
             default: return '';
         }


### PR DESCRIPTION
- Add missing proto message definitions (UpdateConversationRequest,
  DeleteConversationRequest, DeleteConversationResponse,
  GenerateTitleRequest, GenerateTitleResponse) that prevented proto
  compilation and broke conversation management RPCs
- Fix GenerateTitle calling nonexistent provider.stream_chat() method;
  use provider.stream() with correct kwargs and handle string tokens
  instead of treating them as dicts
- Update frontend model lists (ChatView.tsx) to match backend
  MODEL_CATALOG: current OpenAI gpt-5 series, Anthropic Claude 4.x,
  and Google Gemini 3.x models
- Update ConfigureProviderModal default models to match backend
  provider defaults (gpt-5-mini, claude-haiku-4-5, gemini-3-flash)
- Update hardcoded Anthropic model list in cloud.py from deprecated
  Claude 3/3.5 IDs to current claude-opus-4-6, claude-sonnet-4-5,
  claude-haiku-4-5
- Fix Docker Compose frontend port from 5174 to 5173 to match
  gateway CORS_ORIGIN default, preventing cross-origin request failures
- Fix infinite retry loop in App.tsx auto-create conversation effect
  by tracking attempted workspace IDs via ref
- Fix Docker Compose header from "Libre Bird" to "Kestrel"

https://claude.ai/code/session_01AGQAviqBDyqtwuFhjbCLFy