### PR TITLE
audit: fix 11 bugs across frontend, brain, and agent systems

### DIFF
--- a/packages/brain/agent/tools/__init__.py
+++ b/packages/brain/agent/tools/__init__.py
@@ -56,6 +56,15 @@ class ToolRegistry:
         tool = self._definitions.get(name)
         return tool.risk_level if tool else RiskLevel.HIGH  # Unknown = HIGH
 
+    def filter(self, allowed_names: list[str]) -> "ToolRegistry":
+        """Return a new registry containing only the named tools."""
+        filtered = ToolRegistry()
+        for name in allowed_names:
+            if name in self._definitions:
+                filtered._definitions[name] = self._definitions[name]
+                filtered._handlers[name] = self._handlers[name]
+        return filtered
+
     async def execute(self, tool_call: ToolCall) -> ToolResult:
         """
         Execute a tool call and return the result.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -47,7 +47,6 @@ export default function App() {
         if (!currentWorkspace) return;
         try {
             const conv = await conversations.create(currentWorkspace.id);
-            console.log('DEBUG: Created conversation result:', conv);
             setCurrentConversation(conv);
             setInitialMessages([]);
         } catch (err) {

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -173,7 +173,7 @@ export const providers = {
 export const apiKeys = {
     list: () => request<{ keys: ApiKey[] }>('/api-keys'),
     create: (name: string, expiresInDays?: number) =>
-        request<{ id: string; secret: string }>('/api-keys', { method: 'POST', body: { name, expiresInDays } }),
+        request<{ id: string; name: string; key: string; expiresAt: string }>('/api-keys', { method: 'POST', body: { name, expiresInDays } }),
     revoke: (id: string) => request(`/api-keys/${id}`, { method: 'DELETE' }),
 };
 
@@ -217,7 +217,6 @@ export interface ProviderInfo {
 export interface ApiKey {
     id: string;
     name: string;
-    prefix: string;
     createdAt: string;
     expiresAt: string;
 }

--- a/packages/web/src/components/Auth/LoginPage.tsx
+++ b/packages/web/src/components/Auth/LoginPage.tsx
@@ -1,6 +1,30 @@
 import { useState, FormEvent } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 
+function OAuthNotice({ onClose }: { onClose: () => void }) {
+    return (
+        <div style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 10000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0,0,0,0.6)',
+            backdropFilter: 'blur(4px)',
+        }} onClick={onClose}>
+            <div className="card animate-scale-in" style={{ maxWidth: 360, padding: 'var(--space-6)', textAlign: 'center' }} onClick={e => e.stopPropagation()}>
+                <div style={{ fontSize: '2rem', marginBottom: 'var(--space-3)' }}>🔐</div>
+                <h3 style={{ fontWeight: 600, marginBottom: 'var(--space-2)' }}>OAuth Coming Soon</h3>
+                <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.875rem', marginBottom: 'var(--space-4)' }}>
+                    Social login is not yet configured. Please sign in with your email and password for now.
+                </p>
+                <button className="btn btn-primary" onClick={onClose} style={{ width: '100%' }}>Got it</button>
+            </div>
+        </div>
+    );
+}
+
 export function LoginPage() {
     const { login, register } = useAuth();
     const [mode, setMode] = useState<'login' | 'register'>('login');
@@ -8,6 +32,7 @@ export function LoginPage() {
     const [password, setPassword] = useState('');
     const [displayName, setDisplayName] = useState('');
     const [error, setError] = useState('');
+    const [showOAuthNotice, setShowOAuthNotice] = useState(false);
     const [loading, setLoading] = useState(false);
 
     async function handleSubmit(e: FormEvent) {
@@ -118,9 +143,9 @@ export function LoginPage() {
 
                 <div className="auth-divider">or</div>
 
-                {/* OAuth buttons */}
+                {/* OAuth buttons — social login not yet configured */}
                 <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
-                    <button className="btn btn-secondary" style={{ flex: 1 }}>
+                    <button className="btn btn-secondary" style={{ flex: 1, opacity: 0.7 }} onClick={() => setShowOAuthNotice(true)}>
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
                             <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
@@ -129,13 +154,14 @@ export function LoginPage() {
                         </svg>
                         Google
                     </button>
-                    <button className="btn btn-secondary" style={{ flex: 1 }}>
+                    <button className="btn btn-secondary" style={{ flex: 1, opacity: 0.7 }} onClick={() => setShowOAuthNotice(true)}>
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
                         </svg>
                         GitHub
                     </button>
                 </div>
+                {showOAuthNotice && <OAuthNotice onClose={() => setShowOAuthNotice(false)} />}
 
                 {/* Toggle mode */}
                 <p style={{

--- a/packages/web/src/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.tsx
@@ -395,30 +395,48 @@ export function Sidebar({
             </aside>
 
             {/* Delete Confirmation Modal */}
-            {
-                deleteConfirmationId && (
-                    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setDeleteConfirmationId(null)}>
-                        <div className="card animate-fade-in p-6 max-w-sm w-full mx-4" onClick={e => e.stopPropagation()}>
-                            <h3 className="text-lg font-bold mb-2">Delete Conversation</h3>
-                            <p className="text-gray-400 mb-6">Are you sure you want to delete this conversation? This action cannot be undone.</p>
-                            <div className="flex justify-end gap-3">
-                                <button
-                                    className="btn btn-ghost"
-                                    onClick={() => setDeleteConfirmationId(null)}
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    className="btn btn-primary bg-red-600 hover:bg-red-700 border-none"
-                                    onClick={confirmDelete}
-                                >
-                                    Delete
-                                </button>
-                            </div>
+            {deleteConfirmationId && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        inset: 0,
+                        zIndex: 50,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        background: 'rgba(0, 0, 0, 0.6)',
+                        backdropFilter: 'blur(4px)',
+                    }}
+                    onClick={() => setDeleteConfirmationId(null)}
+                >
+                    <div
+                        className="card animate-fade-in"
+                        style={{ maxWidth: 400, width: '100%', margin: '0 var(--space-4)', padding: 'var(--space-6)' }}
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <h3 style={{ fontSize: '1.0625rem', fontWeight: 700, marginBottom: 'var(--space-2)' }}>
+                            Delete Conversation
+                        </h3>
+                        <p style={{ color: 'var(--color-text-secondary)', marginBottom: 'var(--space-6)', fontSize: '0.875rem' }}>
+                            Are you sure you want to delete this conversation? This action cannot be undone.
+                        </p>
+                        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 'var(--space-3)' }}>
+                            <button
+                                className="btn btn-ghost"
+                                onClick={() => setDeleteConfirmationId(null)}
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                className="btn btn-danger"
+                                onClick={confirmDelete}
+                            >
+                                Delete
+                            </button>
                         </div>
                     </div>
-                )
-            }
+                </div>
+            )}
         </>
     );
 }

--- a/packages/web/src/styles/index.css
+++ b/packages/web/src/styles/index.css
@@ -302,6 +302,21 @@ input, textarea {
     animation: slideInLeft 0.3s ease-out;
 }
 
+@keyframes scaleIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.animate-scale-in {
+    animation: scaleIn 0.2s ease-out;
+}
+
 /* ── Typing indicator ──────────────────────────────────────────────── */
 .typing-dots {
     display: flex;


### PR DESCRIPTION
Core chat fixes:
- Save user messages to DB before streaming response in StreamChat so conversation history correctly persists on reload (was only saving assistant responses)
- Fix GenerateTitle to use workspace-configured provider instead of hardcoded local; falls back to first user message if LLM fails

Frontend fixes:
- Delete confirmation modal: replace broken Tailwind classes with inline styles (project has no Tailwind — modal was completely unstyled)
- Add missing `animate-scale-in` CSS keyframe and class (used by ConfigureProviderModal but undefined in design system)
- Remove debug console.log('DEBUG: Created conversation result:', conv) left in App.tsx production code
- Implement API Keys UI: replace stub alert() with full list/create/ revoke interface wired to existing /api/api-keys endpoints
- Fix ApiKey type mismatch (prefix → removed; create response key field)
- Fix OAuth buttons: clicking Google/GitHub now shows "coming soon" modal instead of silently doing nothing
- WebSocket auto-reconnect: add exponential backoff reconnection (1s→2s→4s→8s→15s) so chat recovers after network interruptions
- Auto title generation: use ref flag to prevent duplicate requests and properly handle conversations with pre-loaded messages

Agent/brain fixes:
- ToolRegistry: add filter() method used by Coordinator for specialist delegation (delegation crashed with AttributeError without it)
- CloudProvider + LocalProvider: implement generate_with_tools() for OpenAI, Anthropic, and Google — agent loop called this method on every task execution but it was completely missing, crashing the entire autonomous agent pipeline

https://claude.ai/code/session_015gXmjPqg6W4B4xWRo38wfF