### PR TITLE
Thread workspace and conversation IDs into feedback buttons and handle submission state

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -108,6 +108,7 @@ export default function App() {
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative' }}>
                 <ChatView
                     workspaceId={currentWorkspace?.id || null}
+                    conversationId={currentConversation?.id || null}
                     messages={messages}
                     streamingMessage={streamingMessage}
                     onSendMessage={sendMessage}


### PR DESCRIPTION
### Motivation
- Use the real runtime workspace and conversation identifiers instead of hardcoded values so feedback API calls target the correct workspace and conversation.
- Improve feedback UX by surfacing submission success/failure and avoiding silent failures that leave the UI in an inconsistent state.
- Prevent attempts to submit feedback when context is missing and give a clear inline warning.

### Description
- Added a `conversationId` prop to `ChatView` and passed the active `currentConversation?.id` from `App` into `ChatView`.
- Threaded `workspaceId` and `conversationId` through `MessageBubble` into `FeedbackButtons` for both normal and streaming message paths in `packages/web/src/components/Chat/ChatView.tsx`.
- Replaced the hardcoded endpoint/body values with dynamic values: the POST now goes to `/api/workspaces/${workspaceId}/feedback` and the body sends the real `conversationId` and `messageId`.
- Enhanced `FeedbackButtons` with `feedbackStatus` and `idWarning` states to show success/failure tooltip text, display a short inline warning when IDs are missing, and revert the selected thumb if the API call fails.

### Testing
- Ran `npm --prefix packages/web run build` which completed successfully and produced a build output (TypeScript compile + Vite build).
- Started the dev server with `npm --prefix packages/web run dev` and verified the app served at the dev URL.
- Executed a Playwright script to load the UI and capture a screenshot to validate visual changes; the script ran and produced a screenshot artifact.
- Ran automated linting as part of pre-commit tasks which reported errors (`eslint` surfaced 5 problems) and therefore the lint step failed; this is unrelated to the feedback flow changes but surfaced during validation.

*Context improved by Giga AI: used AGENTS.md guidance to keep changes scoped to the requested chat feedback behavior and referenced the repository data-flow and agent-architecture notes to ensure thread-through of workspace and conversation context.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6be7e01c832abf12617d4eac92e8)