### PR TITLE
fix: telegram image handling, conversation context, and moltbook errors

### DIFF
--- a/packages/brain/agent/tools/moltbook.py
+++ b/packages/brain/agent/tools/moltbook.py
@@ -219,8 +219,9 @@ async def moltbook_action(
 
         return result
     except Exception as e:
-        logger.error(f"Moltbook {action} error: {e}")
-        return {"error": str(e), "action": action}
+        logger.error(f"Moltbook {action} error: {e}", exc_info=True)
+        error_msg = str(e).strip() or repr(e) or f"Moltbook {action} failed"
+        return {"error": error_msg, "action": action}
 
 
 async def _register(name: str = "Kestrel", **kwargs) -> dict:

--- a/packages/gateway/src/channels/telegram.ts
+++ b/packages/gateway/src/channels/telegram.ts
@@ -366,6 +366,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
             attachments.push({
                 type: 'image',
                 url: `tg://${largest.file_id}`,
+                mimeType: 'image/jpeg',
                 size: largest.file_size,
             });
         }


### PR DESCRIPTION
Three bugs fixed:

1. Telegram images ignored (telegram.ts + registry.ts)
   - Photo attachments were missing mimeType so brain decoded JPEG bytes
     as UTF-8 text instead of passing them to the multimodal LLM
   - registry.ts passed parameters:{} — attachments were never forwarded
     to Brain at all; now serialised as parameters.attachments JSON

2. Telegram conversation context lost on every message (registry.ts)
   - registry.ts sent conversationId='' to Brain on every new message,
     causing Brain to create a fresh conversation each time with no history
   - Now uses msg.conversationId (the deterministic UUID the Telegram
     adapter derives from the chat ID) so Brain loads and saves history
     against a stable, persistent conversation

3. Moltbook tool returns {"error":""} for some exceptions (moltbook.py)
   - str(e) can be empty for certain httpx/network exceptions, leaving
     the agent with no useful diagnostic info
   - Falls back to repr(e) when str(e) is empty, and adds exc_info=True
     so the full traceback appears in logs

https://claude.ai/code/session_01K5kHfYQrrkinuKMt94phgt