### PR TITLE
fix(telegram): add forum thread support to prevent replies starting new threads

### DIFF
--- a/packages/gateway/src/channels/telegram/types.ts
+++ b/packages/gateway/src/channels/telegram/types.ts
@@ -10,10 +10,18 @@ export interface TelegramUser {
 export interface TelegramChat {
     id: number;
     type: 'private' | 'group' | 'supergroup' | 'channel';
+    is_forum?: boolean;
+}
+
+export interface TelegramForumTopic {
+    message_thread_id: number;
+    name: string;
+    icon_color: number;
 }
 
 export interface TelegramMessage {
     message_id: number;
+    message_thread_id?: number;
     from?: TelegramUser;
     chat: TelegramChat;
     date: number;


### PR DESCRIPTION
- Add message_thread_id to TelegramMessage type and is_forum to TelegramChat
- Track active thread per user in userThreadMap (userId → threadId)
- Include message_thread_id in all outgoing sendMessage, sendChatAction, and attachment calls
- Make resolveConversationId thread-aware so different forum topics get distinct conversation IDs
- Store threadId in pendingApprovals so approval messages go to the correct topic
- Propagate threadId through StreamHandle.chatContext for streaming responses
- Add /newthread [name] command to create new forum topics
- Update /new to create a new forum topic when used inside a forum group

https://claude.ai/code/session_017vYYsbsSAkWVpVfowVSa6z