### PR TITLE
fix(brain,gateway): break approval loop — execute tool after approval + intercept text approvals

### DIFF
--- a/packages/brain/agent/core/executor.py
+++ b/packages/brain/agent/core/executor.py
@@ -346,7 +346,12 @@ class TaskExecutor:
                 content=approval_needed,
                 progress=self._progress_callback(task),
             )
-            return
+            # Generator suspends here. The loop in loop.py waits for
+            # human approval (polling the DB).  When the consumer resumes
+            # iteration, execution falls through to the tool-execution
+            # code below — so the approved tool actually runs.
+            # If the approval is denied the loop breaks and this
+            # generator is cleaned up without reaching the code below.
 
         yield TaskEvent(
             type=TaskEventType.TOOL_CALLED,


### PR DESCRIPTION
Two bugs caused the approval workflow to loop infinitely:

1. executor.py: _execute_single_tool yielded APPROVAL_NEEDED then immediately
   returned, so the approved tool never actually executed. The loop re-entered
   run_step, the LLM re-suggested the same tool, triggering another approval.
   Fix: remove the premature `return` so the async generator suspends at
   the yield and resumes into the tool-execution code after approval.

2. handlers.ts: typing "I approve" in Telegram created a new agent task
   instead of resolving the pending approval. Fix: intercept approval/denial
   keywords when there are pending approvals for the chat and resolve them
   via handleApproval() before the regular message path.

https://claude.ai/code/session_01TdtXkD1YJ7cRDpLUWJ5xyr