### PR TITLE
fix(infra): resolve container_control, code_execute, and computeruse failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - ${LOCAL_MODEL_DIR:-./models}:/models:ro
       - .:/project # Mount project root for self-improvement git operations
       - ${HOST_MOUNT_ROOT:-/Users}:/host_fs # Host filesystem (tool-level security + human approval for writes)
+      - /var/run/docker.sock:/var/run/docker.sock # Docker socket for container_control tool
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/brain/Dockerfile
+++ b/packages/brain/Dockerfile
@@ -2,11 +2,20 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# System deps for llama-cpp, grpc, and Node.js (for MCP servers)
+# System deps for llama-cpp, grpc, Node.js (for MCP servers), and Docker CLI
+# (container_control tool needs the docker CLI + socket to manage Compose services)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential cmake git curl \
+    build-essential cmake git curl ca-certificates gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+       https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/*
 
 COPY packages/brain/requirements.txt .

--- a/packages/brain/agent/tools/computer_use.py
+++ b/packages/brain/agent/tools/computer_use.py
@@ -190,10 +190,16 @@ async def _call_gemini_computer_use(
 
             if resp.status_code == 429:
                 error_body = resp.text[:500]
+                # Extract retry-after header if present
+                retry_after = resp.headers.get("retry-after", "")
+                retry_hint = f" Retry after {retry_after}s." if retry_after else ""
                 if "quota" in error_body.lower() or "limit: 0" in error_body:
                     raise RuntimeError(
-                        "Gemini API quota exhausted. Check your plan and billing "
-                        "at https://ai.google.dev/gemini-api/docs/rate-limits"
+                        f"Gemini API quota exhausted.{retry_hint} "
+                        "Check your plan and billing "
+                        "at https://ai.google.dev/gemini-api/docs/rate-limits — "
+                        "free-tier keys have very low computer-use limits. "
+                        "Upgrade to a paid plan or use a different GOOGLE_API_KEY."
                     )
                 if attempt < max_retries:
                     delay = 2 ** attempt + 1

--- a/packages/hands/sandbox/Dockerfile
+++ b/packages/hands/sandbox/Dockerfile
@@ -1,15 +1,43 @@
 FROM python:3.11-slim
 
-# Minimal sandbox image for skill execution
+# Sandbox image for skill execution.
+# Includes common system tools and package managers so skills can
+# install their own dependencies at runtime without failing on
+# missing binaries (e.g. git, curl, jq).
 WORKDIR /sandbox
 
-# Install minimal deps
-RUN pip install --no-cache-dir requests beautifulsoup4 httpx
+# ── System tooling ──────────────────────────────────────────────
+# Keep the layer cacheable by sorting packages alphabetically.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    dnsutils \
+    git \
+    jq \
+    openssh-client \
+    procps \
+    rsync \
+    unzip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy entrypoint
+# ── Node.js (LTS) for node_executor and JS-heavy skills ────────
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Pre-installed Python packages ──────────────────────────────
+RUN pip install --no-cache-dir \
+    requests \
+    beautifulsoup4 \
+    httpx \
+    pyyaml \
+    python-dotenv
+
+# ── Entrypoint ─────────────────────────────────────────────────
 COPY entrypoint.py /sandbox/entrypoint.py
 
-# Run as non-root
+# Run as non-root for safety (but with a real home dir for git/npm)
 RUN useradd -m -s /bin/bash sandbox
 USER sandbox
 


### PR DESCRIPTION
Three environment blockers that were preventing Kestrel from using its own tools:

1. container_control — "Docker/Podman CLI not found"
   - Brain Dockerfile: install docker-ce-cli + docker-compose-plugin
   - docker-compose.yml: mount /var/run/docker.sock into brain container

2. code_execute — "git not found" in sandbox
   - Sandbox Dockerfile: add git, curl, wget, jq, Node.js, and other
     common system tools so skills can install deps at runtime

3. computeruse — quota error gave no actionable guidance
   - Improved error message with retry-after header, billing link,
     and suggestion to upgrade API key tier

https://claude.ai/code/session_01RQKLZRFh9VPXvmL2ZbWVac