### PR TITLE
fix(git): prevent credential leaks and handle divergent branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,16 @@ yarn-error.log*
 .env.local
 .env.*.local
 
+# Secrets & credentials (prevent accidental commits)
+**/credentials.json
+**/client_secret*.json
+**/token.json
+**/service-account*.json
+*.key
+*.pem
+*.p12
+*.pfx
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
- Add BLOCKED_FILE_PATTERNS to git tool that prevents staging/committing
  secret files (credentials.json, tokens, keys, .env, etc.)
- _git_add() now auto-detects and excludes sensitive files from staging
- _git_commit() double-checks staging area and auto-unstages secrets
- _git_push() handles divergent branches with automatic rebase retry
- _git_push() detects GH013 repo rule violations and gives actionable error
- _git_pull() uses --rebase to avoid merge commits on divergent branches
- .gitignore updated with credential/secret patterns

These changes prevent the recurring cycle where Kestrel stages credentials,
gets blocked by GitHub secret scanning, then enters a confused state trying
to work around the push failure.

https://claude.ai/code/session_01UbL8Tb1s8qCKusT6Co8ixY