### PR TITLE
feat(self-improve): close the feedback loop and harden the self-improvement pipeline

### DIFF
--- a/packages/brain/agent/tools/self_improve.py
+++ b/packages/brain/agent/tools/self_improve.py
@@ -98,6 +98,7 @@ async def self_improve_action(
     if action == "scan":
         results = await asyncio.to_thread(_deep_scan, package, scan_mode)
         _last_scan_results = results
+        _persist_scan_results(results)
         return results
     elif action == "test":
         return _run_tests(package)

--- a/packages/brain/agent/tools/self_improvement/github_sync.py
+++ b/packages/brain/agent/tools/self_improvement/github_sync.py
@@ -17,7 +17,7 @@ from agent.types import RiskLevel, ToolDefinition
 from .utils import *
 from .ast_analyzer import _deep_scan
 
-_SYNCED_ISSUES_FILE = "/tmp/kestrel_synced_issues.json"
+_SYNCED_ISSUES_FILE = os.path.join(PROJECT_ROOT, ".kestrel", "cache", "kestrel_synced_issues.json")
 
 def _load_synced_hashes() -> set:
     """Load set of issue hashes already synced to GitHub."""


### PR DESCRIPTION
Five interconnected improvements to make Kestrel genuinely learn from
its own self-improvement attempts:

1. Fix broken watchdog error counter — the _count_recent_errors() function
   was a no-op (read a nonexistent logger attr). Now uses a real logging
   handler that counts ERROR+ records, so the auto-rollback watchdog
   actually triggers when patches cause errors.

2. Add historical feedback loop — proposals are now scored using past
   success/failure rates per file and issue type. Files that repeatedly
   fail after patching get deprioritized; patterns that succeed get
   boosted. This prevents the system from repeatedly proposing changes
   that historically get rolled back.

3. Persist scan results and proposals — moved proposals from /tmp to
   .kestrel/cache/ so they survive container restarts. Scan results are
   now written to disk and restored on import, so 'report' works after
   a service restart without re-scanning.

4. Integrate learner insights into LLM analysis — the self-improvement
   scanner now queries improvement history to identify historically
   problematic files and recurring issue types, then feeds these as
   focus areas into the LLM prompt and prioritizes those files for
   deep review.

5. Wire Council multi-agent review into apply pipeline — before a patch
   is applied, it now goes through a Council deliberation where
   Architect, Security, Implementer, Devil's Advocate, and User
   Advocate roles evaluate the proposed change. Council rejections
   block the patch and are recorded in improvement history.

https://claude.ai/code/session_01YVkudKiqcwHHftFRxLQR3h