### PR TITLE
fix: add eslint flat config and scope lint-staged to JS/JSX only

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,37 @@
+// ESLint v10 flat config
+//
+// TypeScript files (.ts/.tsx) are excluded here because no TypeScript parser
+// (@typescript-eslint/parser) is available in this environment — type-level
+// checks are handled by `tsc` instead.
+//
+// JS/JSX files are linted with a minimal set of rules that catch real bugs
+// without producing noise.
+
+export default [
+    {
+        // Globally ignore TS files and build artefacts so ESLint never tries
+        // to parse them without the right parser.
+        ignores: [
+            '**/*.ts',
+            '**/*.tsx',
+            '**/node_modules/**',
+            '**/dist/**',
+            '**/build/**',
+            '**/.next/**',
+            '**/coverage/**',
+        ],
+    },
+    {
+        files: ['**/*.{js,jsx}'],
+        rules: {
+            // Catch likely bugs
+            'no-debugger': 'error',
+            'no-duplicate-case': 'error',
+            'no-empty': ['warn', { allowEmptyCatch: true }],
+            'no-extra-semi': 'warn',
+            'no-unreachable': 'warn',
+            'no-undef': 'off',
+            'no-unused-vars': 'off',
+        },
+    },
+];

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "prepare": "husky install || true"
   },
   "lint-staged": {
-    "**/*.{ts,tsx,js,jsx}": [
+    "**/*.{js,jsx}": [
       "eslint --fix",
+      "prettier --write"
+    ],
+    "**/*.{ts,tsx}": [
       "prettier --write"
     ],
     "**/*.{json,css,md}": [


### PR DESCRIPTION
ESLint v10 requires a flat config file (eslint.config.mjs) which was
missing entirely — causing every pre-commit hook to crash and block all
commits. Added a minimal config covering JS/JSX files with basic bug-
catching rules.

Also split the lint-staged config so ESLint only runs on .js/.jsx files;
.ts/.tsx files go to prettier only, since no @typescript-eslint/parser is
installed and TypeScript's own compiler handles type-level checks.

https://claude.ai/code/session_01H8GTYwfj2ppXrSHwvJj5qP