### PR TITLE
fix: resolve Telegram "sorry something went wrong" on every message

### DIFF
--- a/packages/gateway/src/channels/registry.ts
+++ b/packages/gateway/src/channels/registry.ts
@@ -326,10 +326,15 @@ export class ChannelRegistry {
                         userId: msg.userId,
                         error: chunk.error_message,
                     });
-                    await adapter.send(msg.userId, {
-                        conversationId: msg.conversationId || '',
-                        content: 'Sorry, something went wrong. Please try again.',
-                    });
+
+                    // If we already streamed some content, finalize it
+                    // with the error appended. Otherwise send the error
+                    // message directly so the user sees context.
+                    if (fullContent) {
+                        fullContent += `\n\n⚠️ ${chunk.error_message || 'An error occurred.'}`;
+                    } else {
+                        fullContent = `⚠️ ${chunk.error_message || 'Sorry, something went wrong. Please try again.'}`;
+                    }
                     break;
             }
         }
@@ -383,10 +388,12 @@ export class ChannelRegistry {
                         userId: msg.userId,
                         error: chunk.error_message,
                     });
-                    await adapter.send(msg.userId, {
-                        conversationId: msg.conversationId || '',
-                        content: 'Sorry, something went wrong. Please try again.',
-                    });
+                    // Append or set error content — will be sent on DONE
+                    if (fullContent) {
+                        fullContent += `\n\n⚠️ ${chunk.error_message || 'An error occurred.'}`;
+                    } else {
+                        fullContent = `⚠️ ${chunk.error_message || 'Sorry, something went wrong. Please try again.'}`;
+                    }
                     break;
             }
         }


### PR DESCRIPTION
Three interacting bugs caused all Telegram messages to return a generic
error instead of actual content:

1. tool_parser.py: task_failed events yielded ERROR chunks (chunk_type=3)
   when there was no accumulated content, which the gateway translated
   into "Sorry, something went wrong." Changed to yield CONTENT_DELTA
   with a meaningful failure note instead. Also removed the duplicate
   DONE chunk that conflicted with chat_service.py's own DONE.

2. executor.py: When the verifier rejected a task_complete call, it
   returned early without setting step.status to FAILED. This left the
   step stuck in IN_PROGRESS, causing the agent loop to retry
   indefinitely until budget exhaustion triggered task_failed.

3. registry.ts: ERROR chunks from Brain were handled by immediately
   sending a hardcoded error message and discarding any streamed
   content. Changed to accumulate error text into fullContent so
   the DONE handler can deliver it properly through the streaming
   pipeline (with the actual error message visible to the user).

https://claude.ai/code/session_01A4wZ8EG7zFMVgHrfvYD13U