### PR TITLE
fix: surface MCP server stderr in connection errors and prevent Gmail server crash

### DIFF
--- a/mcp-servers/gmail/server.py
+++ b/mcp-servers/gmail/server.py
@@ -38,8 +38,7 @@ def get_service():
             creds.refresh(Request())
         else:
             if not os.path.exists('credentials.json'):
-                print(json.dumps({"error": "credentials.json not found. Please follow instructions to set up Gmail API."}), flush=True)
-                sys.exit(1)
+                raise RuntimeError("credentials.json not found. Please set up Gmail API OAuth credentials and save them to credentials.json.")
             flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
             creds = flow.run_local_server(port=0)
         with open('token.json', 'w') as token:
@@ -143,7 +142,7 @@ def main():
             sys.stdout.write(out + "\n")
             sys.stdout.flush()
         except Exception as e:
-            out = json.dumps({"jsonrpc": "2.0", "error": {"code": -32603, "message": str(e)}})
+            out = json.dumps({"jsonrpc": "2.0", "id": request.get('id'), "error": {"code": -32603, "message": str(e)}})
             sys.stdout.write(out + "\n")
             sys.stdout.flush()
 


### PR DESCRIPTION
When an MCP server crashes on startup (import error, wrong path, missing
credentials, etc.), the client now captures the server's stderr output and
includes it in the error message instead of the opaque "Server closed
connection". This makes failures self-diagnosable without requiring manual
log inspection.

Also fixes two bugs in the Gmail MCP server:
- `get_service()` called `sys.exit(1)` when credentials.json was missing,
  killing the server process mid-connection. Now raises RuntimeError so the
  exception propagates to main()'s try/except and returns a proper JSON-RPC
  error, keeping the server alive.
- Error responses in `main()` were missing the `id` field, causing the client
  to silently discard them as notifications and time out.

https://claude.ai/code/session_01ENoxmJhXkGin6nJtP7WErg