### PR TITLE
fix: resolve MCP connect disconnection errors

### DIFF
--- a/packages/brain/agent/tools/mcp_client.py
+++ b/packages/brain/agent/tools/mcp_client.py
@@ -161,7 +161,7 @@ class MCPClient:
             tools_result = await self._send_request("tools/list", {})
             self._tools = tools_result.get("result", {}).get("tools", [])
         except Exception as e:
-            logger.debug(f"MCP '{self._name}': tools/list not supported: {e}")
+            logger.debug(f"MCP '{self.name}': tools/list not supported: {e}")
             self._tools = []
 
         return {


### PR DESCRIPTION
Two bugs caused mcp_connect to fail with server disconnection errors:

1. DB-stored credentials (env vars saved via mcp_install) were never
   loaded for built-in servers because the DB lookup was gated on
   `if pool and not command:`. Once the command was resolved from
   BUILTIN_CATALOG the condition was False, silently dropping any
   stored API keys (e.g. GITHUB_PERSONAL_ACCESS_TOKEN). The server
   process then started without credentials, crashed immediately, and
   the client returned "Server closed connection".

   Fix: always query the DB for stored env vars; only use the stored
   server_url when no command has been resolved yet.

2. The except block in MCPClient._initialize referenced self._name
   (non-existent attribute) instead of self.name, causing an
   AttributeError that propagated as a confusing "MCP initialization
   failed" message whenever tools/list raised.

   Fix: one-character change, self._name -> self.name.

https://claude.ai/code/session_01LNoxZC6KvfqX7Vg4YgnntU