### PR TITLE
feat: smart autonomous guardrails — reduce unnecessary approval requests

### DIFF
--- a/packages/brain/agent/approval_memory.py
+++ b/packages/brain/agent/approval_memory.py
@@ -1,0 +1,258 @@
+"""
+Approval Memory — learn from user approval patterns to reduce future interruptions.
+
+Tracks (tool_name, args_pattern) approval history per workspace.  After a user
+approves the same generalized pattern N times (default 3), future matching
+tool calls are auto-approved at the INFORM tier instead of CONFIRM.
+
+Patterns are generalized: file paths become directory wildcards, UUIDs are
+replaced with placeholders, long content strings are collapsed.  This ensures
+that approving "write to /project/src/foo.py" also covers "write to
+/project/src/bar.py" without creating an infinite number of patterns.
+
+Safety invariant: a single denial permanently blocks auto-approval for that
+pattern (denial_count > 0 → never auto-approve).
+"""
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger("brain.agent.approval_memory")
+
+# Number of approvals before auto-approving a pattern
+AUTO_APPROVE_THRESHOLD = 3
+
+# Maximum stored patterns per workspace (prevent unbounded growth)
+MAX_PATTERNS_PER_WORKSPACE = 500
+
+
+@dataclass
+class ApprovalPattern:
+    """A generalized tool+args pattern with approval history."""
+    tool_name: str
+    args_pattern: str       # Generalized JSON pattern
+    pattern_hash: str       # For fast lookup
+    approval_count: int
+    denial_count: int
+    workspace_id: str
+    user_id: str
+
+
+def generalize_args(tool_name: str, tool_args: dict) -> str:
+    """Convert specific tool arguments to a generalized pattern.
+
+    Rules:
+      - File paths: keep the directory prefix, wildcard the filename
+        ``/project/src/utils.py`` → ``/project/src/*``
+      - UUIDs: replace with ``<UUID>``
+      - Numbers > 100: replace with ``<N>``
+      - Strings > 50 chars: replace with ``<CONTENT>``
+      - Keep: action names, tool names, boolean flags, short enums
+    """
+    generalized: dict = {}
+    for key, value in tool_args.items():
+        if isinstance(value, str):
+            # UUID pattern
+            if re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-", value):
+                generalized[key] = "<UUID>"
+            # File path: keep directory, wildcard file
+            elif "/" in value and len(value) > 5:
+                parts = value.rsplit("/", 1)
+                generalized[key] = parts[0] + "/*"
+            # Long content strings
+            elif len(value) > 50:
+                generalized[key] = "<CONTENT>"
+            else:
+                generalized[key] = value  # Keep short strings (actions, enums)
+        elif isinstance(value, bool):
+            generalized[key] = value
+        elif isinstance(value, (int, float)):
+            generalized[key] = value if abs(value) <= 100 else "<N>"
+        elif isinstance(value, dict):
+            generalized[key] = "<OBJECT>"
+        elif isinstance(value, list):
+            generalized[key] = f"<LIST:{len(value)}>"
+        else:
+            generalized[key] = "<OTHER>"
+
+    return json.dumps(generalized, sort_keys=True)
+
+
+def pattern_hash(tool_name: str, args_pattern: str) -> str:
+    """Deterministic hash for a tool+pattern combination."""
+    key = f"{tool_name}:{args_pattern}"
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+class ApprovalMemory:
+    """Persistent approval pattern memory backed by PostgreSQL.
+
+    Provides both async methods (for recording after approvals) and a
+    sync-safe cache for fast lookups during the guardrails check.
+    """
+
+    def __init__(self, pool):
+        self._pool = pool
+        # In-memory cache: pattern_hash → (approval_count, denial_count)
+        # Populated on first query per workspace, refreshed periodically.
+        self._cache: dict[str, dict[str, tuple[int, int]]] = {}
+
+    async def record_approval(
+        self,
+        tool_name: str,
+        tool_args: dict,
+        approved: bool,
+        user_id: str,
+        workspace_id: str,
+    ) -> None:
+        """Record an approval/denial decision for pattern learning."""
+        args_pat = generalize_args(tool_name, tool_args)
+        ph = pattern_hash(tool_name, args_pat)
+
+        if approved:
+            await self._pool.execute(
+                """
+                INSERT INTO approval_patterns
+                    (pattern_hash, tool_name, args_pattern, workspace_id, user_id,
+                     approval_count, denial_count, last_approved_at)
+                VALUES ($1, $2, $3::jsonb, $4, $5, 1, 0, NOW())
+                ON CONFLICT (pattern_hash, workspace_id) DO UPDATE SET
+                    approval_count = approval_patterns.approval_count + 1,
+                    last_approved_at = NOW()
+                """,
+                ph, tool_name, args_pat, workspace_id, user_id,
+            )
+        else:
+            await self._pool.execute(
+                """
+                INSERT INTO approval_patterns
+                    (pattern_hash, tool_name, args_pattern, workspace_id, user_id,
+                     approval_count, denial_count, last_denied_at)
+                VALUES ($1, $2, $3::jsonb, $4, $5, 0, 1, NOW())
+                ON CONFLICT (pattern_hash, workspace_id) DO UPDATE SET
+                    denial_count = approval_patterns.denial_count + 1,
+                    last_denied_at = NOW()
+                """,
+                ph, tool_name, args_pat, workspace_id, user_id,
+            )
+
+        # Update local cache
+        ws_cache = self._cache.setdefault(workspace_id, {})
+        prev = ws_cache.get(ph, (0, 0))
+        if approved:
+            ws_cache[ph] = (prev[0] + 1, prev[1])
+        else:
+            ws_cache[ph] = (prev[0], prev[1] + 1)
+
+    async def load_workspace_cache(self, workspace_id: str) -> None:
+        """Pre-load all patterns for a workspace into the in-memory cache."""
+        rows = await self._pool.fetch(
+            """
+            SELECT pattern_hash, approval_count, denial_count
+            FROM approval_patterns
+            WHERE workspace_id = $1
+            ORDER BY last_approved_at DESC NULLS LAST
+            LIMIT $2
+            """,
+            workspace_id,
+            MAX_PATTERNS_PER_WORKSPACE,
+        )
+        ws_cache: dict[str, tuple[int, int]] = {}
+        for row in rows:
+            ws_cache[row["pattern_hash"]] = (
+                row["approval_count"],
+                row["denial_count"],
+            )
+        self._cache[workspace_id] = ws_cache
+
+    def should_auto_approve_sync(
+        self,
+        tool_name: str,
+        tool_args: dict,
+        workspace_id: str,
+    ) -> tuple[bool, Optional[str]]:
+        """Sync-safe check using the in-memory cache.
+
+        Returns ``(should_auto, reason_or_none)``.
+        Called from ``Guardrails.check_tool()`` which is synchronous.
+        """
+        if not workspace_id:
+            return False, None
+
+        ws_cache = self._cache.get(workspace_id)
+        if ws_cache is None:
+            return False, None
+
+        args_pat = generalize_args(tool_name, tool_args)
+        ph = pattern_hash(tool_name, args_pat)
+
+        counts = ws_cache.get(ph)
+        if counts is None:
+            return False, None
+
+        approvals, denials = counts
+
+        # Never auto-approve if there have been denials
+        if denials > 0:
+            return False, None
+
+        if approvals >= AUTO_APPROVE_THRESHOLD:
+            return True, (
+                f"Auto-approved: '{tool_name}' pattern approved "
+                f"{approvals} times previously"
+            )
+
+        return False, None
+
+    async def should_auto_approve(
+        self,
+        tool_name: str,
+        tool_args: dict,
+        workspace_id: str,
+    ) -> tuple[bool, Optional[str]]:
+        """Async version — queries DB if cache miss."""
+        # Try cache first
+        ok, reason = self.should_auto_approve_sync(tool_name, tool_args, workspace_id)
+        if ok:
+            return True, reason
+
+        if not workspace_id:
+            return False, None
+
+        # Cache miss — query DB
+        args_pat = generalize_args(tool_name, tool_args)
+        ph = pattern_hash(tool_name, args_pat)
+
+        row = await self._pool.fetchrow(
+            """
+            SELECT approval_count, denial_count
+            FROM approval_patterns
+            WHERE pattern_hash = $1 AND workspace_id = $2
+            """,
+            ph, workspace_id,
+        )
+
+        if not row:
+            return False, None
+
+        approvals = row["approval_count"]
+        denials = row["denial_count"]
+
+        # Update cache
+        ws_cache = self._cache.setdefault(workspace_id, {})
+        ws_cache[ph] = (approvals, denials)
+
+        if denials > 0:
+            return False, None
+
+        if approvals >= AUTO_APPROVE_THRESHOLD:
+            return True, (
+                f"Auto-approved: '{tool_name}' pattern approved "
+                f"{approvals} times previously"
+            )
+
+        return False, None

--- a/packages/brain/agent/types.py
+++ b/packages/brain/agent/types.py
@@ -54,6 +54,21 @@ class ApprovalStatus(str, Enum):
     EXPIRED = "expired"
 
 
+class ApprovalTier(str, Enum):
+    """Approval tiers for tool execution — from most to least permissive."""
+    SILENT = "silent"       # Auto-approve, no notification
+    INFORM = "inform"       # Auto-approve, log/notify user (non-blocking)
+    CONFIRM = "confirm"     # Pause and ask user before executing
+    BLOCK = "block"         # Always blocked, cannot execute
+
+
+class AutonomyLevel(str, Enum):
+    """Workspace-level autonomy presets."""
+    CAUTIOUS = "cautious"       # auto_approve_risk=LOW, council at complexity>5
+    BALANCED = "balanced"       # auto_approve_risk=MEDIUM, council at complexity>7
+    AUTONOMOUS = "autonomous"   # auto_approve_risk=HIGH, council at complexity>9
+
+
 # ── Tool Types ───────────────────────────────────────────────────────
 
 
@@ -216,6 +231,7 @@ class GuardrailConfig:
     max_tool_calls: int = 80
     max_wall_time_seconds: int = 600
     auto_approve_risk: RiskLevel = RiskLevel.MEDIUM
+    autonomy_level: AutonomyLevel = AutonomyLevel.BALANCED
     blocked_patterns: list[str] = field(default_factory=list)
     allowed_domains: list[str] = field(default_factory=list)
     require_approval_tools: list[str] = field(default_factory=list)
@@ -227,6 +243,7 @@ class GuardrailConfig:
             "max_tool_calls": self.max_tool_calls,
             "max_wall_time_seconds": self.max_wall_time_seconds,
             "auto_approve_risk": self.auto_approve_risk.value,
+            "autonomy_level": self.autonomy_level.value,
             "blocked_patterns": self.blocked_patterns,
             "allowed_domains": self.allowed_domains,
             "require_approval_tools": self.require_approval_tools,
@@ -240,6 +257,7 @@ class GuardrailConfig:
             max_tool_calls=data.get("max_tool_calls", 50),
             max_wall_time_seconds=data.get("max_wall_time_seconds", 600),
             auto_approve_risk=RiskLevel(data.get("auto_approve_risk", "medium")),
+            autonomy_level=AutonomyLevel(data.get("autonomy_level", "balanced")),
             blocked_patterns=data.get("blocked_patterns", []),
             allowed_domains=data.get("allowed_domains", []),
             require_approval_tools=data.get("require_approval_tools", []),
@@ -306,6 +324,7 @@ class TaskEventType(str, Enum):
     TOOL_RESULT = "tool_result"
     STEP_COMPLETE = "step_complete"
     APPROVAL_NEEDED = "approval_needed"
+    TOOL_AUTO_APPROVED = "tool_auto_approved"
     THINKING = "thinking"
     VERIFIER_STARTED = "verifier_started"
     VERIFIER_PASSED = "verifier_passed"

--- a/packages/brain/migrations/014_approval_memory.sql
+++ b/packages/brain/migrations/014_approval_memory.sql
@@ -1,0 +1,25 @@
+-- 014_approval_memory.sql — Approval pattern learning for autonomous execution
+--
+-- Tracks generalized (tool_name, args_pattern) approval history per workspace.
+-- After a user approves the same pattern N times, the agent auto-approves
+-- future matching tool calls without blocking.
+
+CREATE TABLE IF NOT EXISTS approval_patterns (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    pattern_hash    TEXT NOT NULL,
+    tool_name       TEXT NOT NULL,
+    args_pattern    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    workspace_id    UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    approval_count  INTEGER NOT NULL DEFAULT 0,
+    denial_count    INTEGER NOT NULL DEFAULT 0,
+    last_approved_at TIMESTAMPTZ,
+    last_denied_at  TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (pattern_hash, workspace_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_patterns_lookup
+    ON approval_patterns(pattern_hash, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_approval_patterns_workspace
+    ON approval_patterns(workspace_id);


### PR DESCRIPTION
Root cause: 36 of 53 registered tools defaulted to HIGH risk in the
guardrails hardcoded map, triggering approval prompts even for routine
operations like MCP searches, session listing, and file reads.

Changes:
- Fix _get_tool_risk to consult tool registry definitions (authoritative)
  before falling back to the hardcoded map, and default unknowns to
  MEDIUM instead of HIGH
- Add contextual risk adjustment: git status→LOW, mcp_call with
  read-like tools→LOW, file_write to system paths→HIGH
- Implement 4-tier approval system (SILENT/INFORM/CONFIRM/BLOCK)
  replacing binary approve/deny
- Raise council trigger threshold from 5.0→7.0 complexity, allow
  MEDIUM-risk plans to skip council review
- Council soft-inform on conditional verdicts instead of hard-blocking
- Add approval memory system that learns from user patterns: after 3
  approvals of the same tool+args pattern, auto-approve future matches
- Pass auto_approve_risk and autonomy_level from workspace settings
  through chat_service config

https://claude.ai/code/session_01GwnsW9BpnndNp4uRJGyepq