### PR TITLE
fix: prevent premature task completion when steps remain pending

### DIFF
--- a/packages/brain/agent/tools/human.py
+++ b/packages/brain/agent/tools/human.py
@@ -102,8 +102,14 @@ async def task_complete(
     artifacts: Optional[list[str]] = None,
 ) -> dict:
     """
-    Mark the current step as complete.
-    The agent loop checks for this tool call and updates step status.
+    Signal that the ENTIRE task goal has been fully achieved.
+
+    Only call this when every part of the user's original request has been
+    completed — not when a single intermediate step finishes.  If the current
+    step is done but more steps remain, simply return without calling this tool
+    and the agent loop will advance to the next step automatically.
+
+    The agent loop checks for this tool call and updates task status.
     """
     result = {
         "summary": summary,


### PR DESCRIPTION
Kestrel was declaring "Task completed successfully" after finishing only
the first step of a multi-step plan, skipping all remaining steps. Three
root causes addressed:

1. System prompt told the LLM to call task_complete when "the step is
   complete" — now clarifies it should only be called when the ENTIRE
   goal is achieved.

2. task_complete tool docstring said "Mark the current step as complete"
   — updated to make clear it signals full task completion.

3. Executor blindly skipped all pending steps whenever task_complete was
   called — now checks for remaining pending steps and continues
   execution instead of skipping them.

https://claude.ai/code/session_01BbkCRzK1zwnFQpXpBQs6HR