### PR TITLE
Add desktop-first native/hybrid startup profile with safe defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Ever wanted an AI assistant that doesn't just reply to your messages, but actually thinks, argues with itself, spins up Docker containers, and executes real-world actions while you sip your coffee? Welcome to **Kestrel**.
 
-We firmly believe your data should stay yours. Kestrel is a privacy-first, heavily-armed (with tools) AI engine that runs *entirely* on your own infrastructure. You can hook it up to lightweight local MLX models on Apple Silicon, or plug in heavy hitters like Gemini, Claude, or GPT-4.
+We firmly believe your data should stay yours. Kestrel is a privacy-first, heavily-armed (with tools) AI engine that runs _entirely_ on your own infrastructure. You can hook it up to lightweight local MLX models on Apple Silicon, or plug in heavy hitters like Gemini, Claude, or GPT-4.
 
 ---
 
@@ -26,8 +26,8 @@ We firmly believe your data should stay yours. Kestrel is a privacy-first, heavi
 Because typical chatbots are boring. Kestrel has agency.
 
 - � **Multi-Phase Cognitive Loop:** It doesn't just guess an answer. It accesses persistent memory, generates a multi-step plan, uses sandboxed tools, and reflects on whether it messed up.
-- 🏛️ **The Council:** Got a highly complex prompt? Kestrel convenes a literal *Multi-Agent Debate*. The Architect, the Security Expert, the Implementer, and the Devil's Advocate will argue in real-time until they reach a consensus.
-- �️ **See Everything:** The *KestrelProcessBar* in the UI streams the agent's internal monologue, memory recalls, and council votes. Zero black boxes.
+- 🏛️ **The Council:** Got a highly complex prompt? Kestrel convenes a literal _Multi-Agent Debate_. The Architect, the Security Expert, the Implementer, and the Devil's Advocate will argue in real-time until they reach a consensus.
+- �️ **See Everything:** The _KestrelProcessBar_ in the UI streams the agent's internal monologue, memory recalls, and council votes. Zero black boxes.
 - 📦 **Sandboxed Toolkit:** 30+ built-in skills (web scraping, shell execution, GitHub manipulating, smart-home toggling) that run securely in isolated Docker containers via the `Hands` service.
 - 📱 **Omnipresent:** Chat via the gorgeous Web UI, native macOS app, Telegram, Discord, or WhatsApp. It's the exact same persistent brain everywhere.
 
@@ -40,7 +40,7 @@ Kestrel is built like a tank, split into clean, modular microservices (because m
 ```mermaid
 graph TD
     User([You, in your pajamas]) <-->|Web/Discord/Telegram/Voice| Gateway
-    
+
     subgraph Kestrel Stack
         Gateway[Gateway Node.js<br>WebSocket/REST Router]
         Brain[The Brain Python<br>Cognitive Engine & Planning]
@@ -58,6 +58,7 @@ graph TD
 ```
 
 ### The Core Microservices:
+
 1. **The Brain (Python / gRPC):** The absolute core. Orchestrates the Plan → Execute → Reflect loop, coordinates the Council, accesses persistent Vector Memory (Chroma / pgvector), and manages 30+ tools. Recently heavily modularized into clean `core`, `memory`, and `services` namespaces!
 2. **The Hands (Python / gRPC):** The executing muscles. Spawns secure, transient Docker containers to run risky code, fetch URLs, and manipulate files without nuking your host machine.
 3. **The Gateway (Node.js / TS):** The fast, lightweight router that handles JWT auth, WebSockets, rate limiting, and normalizes inputs from Telegram, Discord, and Web clients.
@@ -81,10 +82,12 @@ Kestrel comes equipped with enough tools to build an empire (or at least automat
 Want to unleash Kestrel on your local network?
 
 ### Prerequisites
+
 - Docker & Docker Compose
 - LLM API Keys (OpenAI, Anthropic, or Google) **OR** a local GGUF model if you're feeling entirely off-grid.
 
 ### 1-2-3 Deploy
+
 ```bash
 # 1. Grab the code
 git clone https://github.com/John-MiracleWorker/Kestrel.git
@@ -97,7 +100,8 @@ code .env # Add your API keys and secure passwords
 # 3. Fire it all up
 docker compose up -d --build
 ```
-*Boom.* Head over to **http://localhost:5173**. Your new hyper-capable assistant awaits.
+
+_Boom._ Head over to **http://localhost:5173**. Your new hyper-capable assistant awaits.
 
 ---
 
@@ -106,6 +110,7 @@ docker compose up -d --build
 The codebase is meticulously typed and documented. We love PRs!
 
 If you want to spin up services natively instead of in Docker:
+
 ```bash
 # Terminal 1: Gateway
 cd packages/gateway && npm install && npm run dev
@@ -118,17 +123,35 @@ cd packages/web && npm install && npm run dev
 ```
 
 Run tests natively:
+
 ```bash
 npm run test --prefix packages/gateway
 pytest packages/brain/tests/
 ```
 
+### Desktop-first native/hybrid startup profile
+
+If you are migrating from Docker-first to desktop-first, use the documented startup profile:
+
+```bash
+cp config/startup/native-hybrid.env.example config/startup/native-hybrid.env
+./scripts/startup/native-hybrid.sh check
+./scripts/startup/native-hybrid.sh up
+```
+
+- `screen-agent` is enabled by default.
+- Native runtime is selected.
+- Docker-heavy subsystems are optional.
+- Native write/exec tools are disabled by default until policy is configured.
+
+See the full migration guide and OS compatibility matrix in `docs/desktop-first-migration.md`.
+
 ---
 
 ## 🛡️ Security Note
 
-Kestrel is *powerful*. It can run code and access your filesystem. We use Row-Level Security in Postgres, Docker sandboxing, and strict JWT auth to keep you safe, but **please do not expose the Gateway port (8741) to the public internet** without putting it behind a reverse proxy (like Nginx or Caddy) with proper TLS enabled. 
+Kestrel is _powerful_. It can run code and access your filesystem. We use Row-Level Security in Postgres, Docker sandboxing, and strict JWT auth to keep you safe, but **please do not expose the Gateway port (8741) to the public internet** without putting it behind a reverse proxy (like Nginx or Caddy) with proper TLS enabled.
 
 ---
 
-*Built with ❤️ (and entirely too much caffeine) by the Kestrel Team.*
+_Built with ❤️ (and entirely too much caffeine) by the Kestrel Team._

--- a/config/startup/native-hybrid.env.example
+++ b/config/startup/native-hybrid.env.example
@@ -1,0 +1,33 @@
+# Kestrel native/hybrid startup profile (desktop-first)
+# Copy to config/startup/native-hybrid.env and adjust for your machine.
+
+# Runtime mode metadata for scripts/docs.
+KESTREL_RUNTIME_MODE=native
+
+# Always run host screen-agent for computer-use actions.
+KESTREL_ENABLE_SCREEN_AGENT=true
+SCREEN_AGENT_HOST=0.0.0.0
+SCREEN_AGENT_PORT=9800
+SCREEN_AGENT_URL=http://127.0.0.1:9800
+
+# Optional Docker-heavy subsystems for hybrid mode.
+# Set false for pure-native mode.
+KESTREL_ENABLE_DOCKER_SUBSYSTEMS=true
+# Valid names: postgres,redis,hands,frontend,gateway,brain
+KESTREL_DOCKER_SUBSYSTEMS=postgres,redis,hands
+
+# Safe defaults: native write/exec tools are disabled until policy exists.
+KESTREL_ENABLE_HOST_WRITE=false
+KESTREL_ENABLE_HOST_EXEC=false
+# Required when KESTREL_ENABLE_HOST_WRITE/EXEC are true.
+KESTREL_NATIVE_POLICY_FILE=$HOME/.kestrel/native-tools-policy.yml
+
+# Native service startup commands.
+KESTREL_BRAIN_CMD="cd packages/brain && python server.py"
+KESTREL_GATEWAY_CMD="cd packages/gateway && npm run dev"
+KESTREL_WEB_CMD="cd packages/web && npm run dev"
+KESTREL_SCREEN_AGENT_CMD="cd packages/screen-agent && python screen_agent.py"
+
+# Optional host dependency hints.
+KESTREL_REQUIRED_NODE_MAJOR=18
+KESTREL_REQUIRED_PYTHON_MAJOR=3

--- a/docs/desktop-first-migration.md
+++ b/docs/desktop-first-migration.md
@@ -1,0 +1,97 @@
+# Desktop-first startup profile (native/hybrid)
+
+This guide adds a **desktop-first** path for Kestrel while preserving Docker compatibility.
+
+## What this profile does
+
+- Selects native runtime mode metadata (`KESTREL_RUNTIME_MODE=native`).
+- Enables `screen-agent` by default (host-run process).
+- Keeps Docker-heavy subsystems optional via `KESTREL_ENABLE_DOCKER_SUBSYSTEMS` + `KESTREL_DOCKER_SUBSYSTEMS`.
+- Defaults host-native write/exec tools to **disabled** until policy is configured:
+    - `KESTREL_ENABLE_HOST_WRITE=false`
+    - `KESTREL_ENABLE_HOST_EXEC=false`
+
+The profile files are:
+
+- `config/startup/native-hybrid.env.example`
+- `scripts/startup/native-hybrid.sh`
+
+## Quick start
+
+```bash
+cp config/startup/native-hybrid.env.example config/startup/native-hybrid.env
+./scripts/startup/native-hybrid.sh check
+./scripts/startup/native-hybrid.sh up
+```
+
+## Safety model for native write/exec tools
+
+Native write/exec registration in the Brain now follows startup-policy flags:
+
+- `KESTREL_ENABLE_HOST_WRITE=true` registers `host_write`.
+- `KESTREL_ENABLE_HOST_EXEC=true` registers `host_shell` and `host_python`.
+- If either flag is true, `KESTREL_NATIVE_POLICY_FILE` must exist.
+
+Recommended policy location:
+
+```text
+~/.kestrel/native-tools-policy.yml
+```
+
+Example allowlist seed:
+
+```yaml
+allowed_commands:
+    - '^git status$'
+    - '^git diff'
+    - '^npm run test'
+```
+
+## Preflight checks performed by startup script
+
+`./scripts/startup/native-hybrid.sh check` validates:
+
+1. Host dependencies: `python3`, `node`, `npm` (and `docker` when hybrid mode enabled).
+2. Version guards: minimum Python and Node major versions from the profile.
+3. Policy requirements when host write/exec are enabled.
+4. Repo writability and host permission reminders for screen automation.
+
+## Migration from Docker-first to desktop-first
+
+### 1) Keep your existing Docker flow intact
+
+Your current Docker-first command remains valid:
+
+```bash
+docker compose up -d --build
+```
+
+### 2) Introduce the desktop-first profile
+
+- Copy `config/startup/native-hybrid.env.example` to `config/startup/native-hybrid.env`.
+- Keep default safe flags (`KESTREL_ENABLE_HOST_WRITE=false`, `KESTREL_ENABLE_HOST_EXEC=false`).
+
+### 3) Choose runtime style per machine
+
+- **Pure native desktop:** set `KESTREL_ENABLE_DOCKER_SUBSYSTEMS=false`.
+- **Hybrid desktop:** keep `KESTREL_ENABLE_DOCKER_SUBSYSTEMS=true` and run only heavy subsystems (default: `postgres,redis,hands`).
+
+### 4) Enable native write/exec intentionally
+
+Only after you establish your policy file:
+
+- Create `~/.kestrel/native-tools-policy.yml`.
+- Set `KESTREL_ENABLE_HOST_WRITE=true` and/or `KESTREL_ENABLE_HOST_EXEC=true`.
+- Re-run `./scripts/startup/native-hybrid.sh check`.
+
+## Compatibility matrix
+
+| OS                      | Native core services (brain/gateway/web) | Screen-agent                        | Hybrid Docker subsystems          | Notes                                                                                         |
+| ----------------------- | ---------------------------------------- | ----------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------- |
+| macOS                   | ✅ Supported                             | ✅ Best supported                   | ✅ Supported                      | Grant Screen Recording + Accessibility permissions to terminal/app running `screen-agent`.    |
+| Linux (desktop session) | ✅ Supported                             | ⚠️ Supported with environment setup | ✅ Supported                      | Requires GUI session and compatible screenshot/input backends for `pyautogui`/display server. |
+| Windows (native shell)  | ⚠️ Experimental                          | ⚠️ Experimental                     | ✅ Recommended via Docker Desktop | Prefer WSL2 or Docker-backed hybrid mode for predictable service orchestration.               |
+
+## Operational recommendation
+
+For teams migrating gradually, start with **hybrid mode** (`postgres,redis,hands` in Docker; brain/gateway/web/screen-agent native), then disable Docker subsystems one-by-one once host dependencies and policies are stable.

--- a/packages/brain/agent/tools/__init__.py
+++ b/packages/brain/agent/tools/__init__.py
@@ -7,6 +7,7 @@ and result formatting.
 """
 
 import logging
+import os
 import time
 from typing import Callable, Dict, Optional
 
@@ -232,10 +233,13 @@ def build_tool_registry(hands_client=None, vector_store=None, pool=None) -> Tool
     from agent.tools.system_tools import register_system_tools
     from agent.tools.host_execution import register_host_execution_tools
 
+    native_write_enabled = os.getenv("KESTREL_ENABLE_HOST_WRITE", "false").lower() in {"1", "true", "yes", "on"}
+    native_exec_enabled = os.getenv("KESTREL_ENABLE_HOST_EXEC", "false").lower() in {"1", "true", "yes", "on"}
+
     register_code_tools(registry, hands_client=hands_client)
     register_web_tools(registry)
     register_file_tools(registry)
-    register_host_file_tools(registry, vector_store=vector_store)
+    register_host_file_tools(registry, vector_store=vector_store, enable_write=native_write_enabled)
     register_data_tools(registry)
     register_memory_tools(registry, vector_store=vector_store)
     register_human_tools(registry)
@@ -243,7 +247,7 @@ def build_tool_registry(hands_client=None, vector_store=None, pool=None) -> Tool
     register_moltbook_autonomous_tools(registry)
     register_schedule_tools(registry)
     register_system_tools(registry)
-    register_host_execution_tools(registry)
+    register_host_execution_tools(registry, enable_native_exec=native_exec_enabled)
 
     # Model swap (search + switch models across Ollama & cloud providers)
     from agent.tools.model_swap import register_model_swap_tools

--- a/packages/brain/agent/tools/host_execution.py
+++ b/packages/brain/agent/tools/host_execution.py
@@ -176,7 +176,11 @@ async def execute_host_python(code: str) -> dict:
             except Exception:
                 pass
 
-def register_host_execution_tools(registry) -> None:
+def register_host_execution_tools(registry, enable_native_exec: bool = False) -> None:
+    if not enable_native_exec:
+        logger.info("Skipping host execution tool registration (disabled by startup policy)")
+        return
+
     registry.register(
         definition=ToolDefinition(
             name="host_shell",

--- a/packages/brain/agent/tools/host_files.py
+++ b/packages/brain/agent/tools/host_files.py
@@ -21,7 +21,7 @@ from .fs.read import host_read, host_batch_read
 from .fs.write import host_write
 from .fs.explore import host_list, host_search, host_tree, host_find, project_recall
 
-def register_host_file_tools(registry, vector_store=None) -> None:
+def register_host_file_tools(registry, vector_store=None, enable_write: bool = False) -> None:
     """Register host filesystem tools."""
     # Inject vector store for project context memoization
     if vector_store:
@@ -175,41 +175,46 @@ def register_host_file_tools(registry, vector_store=None) -> None:
         handler=host_search,
     )
 
-    registry.register(
-        definition=ToolDefinition(
-            name="host_write",
-            description=(
-                "Write content to a file on the user's host filesystem. "
-                "⚠️ This is a HIGH-RISK operation — it will modify files on the "
-                "user's actual machine and requires human approval before execution. "
-                "A diff preview is shown to the user for review."
-            ),
-            parameters={
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Absolute file path or path relative to first mounted directory",
+    if enable_write:
+        registry.register(
+            definition=ToolDefinition(
+                name="host_write",
+                description=(
+                    "Write content to a file on the user's host filesystem. "
+                    "⚠️ This is a HIGH-RISK operation — it will modify files on the "
+                    "user's actual machine and requires human approval before execution. "
+                    "A diff preview is shown to the user for review."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute file path or path relative to first mounted directory",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Full content to write to the file",
+                        },
+                        "create_dirs": {
+                            "type": "boolean",
+                            "description": "Create parent directories if they don't exist",
+                            "default": False,
+                        },
                     },
-                    "content": {
-                        "type": "string",
-                        "description": "Full content to write to the file",
-                    },
-                    "create_dirs": {
-                        "type": "boolean",
-                        "description": "Create parent directories if they don't exist",
-                        "default": False,
-                    },
+                    "required": ["path", "content"],
                 },
-                "required": ["path", "content"],
-            },
-            risk_level=RiskLevel.HIGH,
-            requires_approval=True,
-            timeout_seconds=15,
-            category="host_file",
-        ),
-        handler=host_write,
-    )
+                risk_level=RiskLevel.HIGH,
+                requires_approval=True,
+                timeout_seconds=15,
+                category="host_file",
+            ),
+            handler=host_write,
+        )
+    else:
+        logger.info(
+            "Skipping host_write tool registration (disabled by startup policy)"
+        )
 
     registry.register(
         definition=ToolDefinition(

--- a/scripts/startup/native-hybrid.sh
+++ b/scripts/startup/native-hybrid.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROFILE_PATH="${KESTREL_PROFILE:-$ROOT_DIR/config/startup/native-hybrid.env}"
+CMD="${1:-check}"
+
+if [[ ! -f "$PROFILE_PATH" ]]; then
+  echo "[ERROR] Profile not found: $PROFILE_PATH"
+  echo "Copy config/startup/native-hybrid.env.example to config/startup/native-hybrid.env first."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$PROFILE_PATH"
+
+is_true() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "[ERROR] Missing dependency: $1"
+    return 1
+  fi
+}
+
+check_versions() {
+  local py_major node_major
+  py_major="$(python3 -c 'import sys; print(sys.version_info.major)' 2>/dev/null || echo 0)"
+  node_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+
+  if [[ "$py_major" -lt "${KESTREL_REQUIRED_PYTHON_MAJOR:-3}" ]]; then
+    echo "[ERROR] Python major version is too old: $py_major"
+    return 1
+  fi
+
+  if [[ "$node_major" -lt "${KESTREL_REQUIRED_NODE_MAJOR:-18}" ]]; then
+    echo "[ERROR] Node major version is too old: $node_major"
+    return 1
+  fi
+
+  return 0
+}
+
+check_policy() {
+  if is_true "${KESTREL_ENABLE_HOST_WRITE:-false}" || is_true "${KESTREL_ENABLE_HOST_EXEC:-false}"; then
+    if [[ -z "${KESTREL_NATIVE_POLICY_FILE:-}" ]]; then
+      echo "[ERROR] KESTREL_NATIVE_POLICY_FILE must be set when host write/exec is enabled."
+      return 1
+    fi
+    if [[ ! -f "$KESTREL_NATIVE_POLICY_FILE" ]]; then
+      echo "[ERROR] Native policy file missing: $KESTREL_NATIVE_POLICY_FILE"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+check_permissions() {
+  if [[ ! -w "$ROOT_DIR" ]]; then
+    echo "[ERROR] Repo root is not writable: $ROOT_DIR"
+    return 1
+  fi
+
+  if is_true "${KESTREL_ENABLE_SCREEN_AGENT:-true}"; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      echo "[INFO] macOS detected: ensure Screen Recording + Accessibility are granted to your terminal for screen-agent."
+    else
+      echo "[INFO] Non-macOS host: ensure desktop session allows screenshot/input automation for screen-agent."
+    fi
+  fi
+  return 0
+}
+
+run_checks() {
+  require_cmd python3
+  require_cmd node
+  require_cmd npm
+  check_versions
+  check_policy
+  check_permissions
+
+  if is_true "${KESTREL_ENABLE_DOCKER_SUBSYSTEMS:-true}"; then
+    require_cmd docker
+    echo "[INFO] Docker-enabled hybrid mode for: ${KESTREL_DOCKER_SUBSYSTEMS:-postgres,redis,hands}"
+  else
+    echo "[INFO] Pure native mode selected (Docker subsystems disabled)."
+  fi
+
+  echo "[OK] Startup checks passed for profile: $PROFILE_PATH"
+}
+
+start_native_services() {
+  mkdir -p "$ROOT_DIR/.kestrel/logs"
+
+  if is_true "${KESTREL_ENABLE_SCREEN_AGENT:-true}"; then
+    (cd "$ROOT_DIR" && nohup bash -lc "$KESTREL_SCREEN_AGENT_CMD" > .kestrel/logs/screen-agent.log 2>&1 &)
+    echo "[STARTED] screen-agent (log: .kestrel/logs/screen-agent.log)"
+  fi
+
+  if is_true "${KESTREL_ENABLE_DOCKER_SUBSYSTEMS:-true}"; then
+    local services
+    services="${KESTREL_DOCKER_SUBSYSTEMS:-postgres,redis,hands}"
+    (cd "$ROOT_DIR" && docker compose up -d $(echo "$services" | tr ',' ' '))
+    echo "[STARTED] docker subsystems: $services"
+  fi
+
+  (cd "$ROOT_DIR" && nohup bash -lc "$KESTREL_BRAIN_CMD" > .kestrel/logs/brain.log 2>&1 &)
+  echo "[STARTED] brain (log: .kestrel/logs/brain.log)"
+
+  (cd "$ROOT_DIR" && nohup bash -lc "$KESTREL_GATEWAY_CMD" > .kestrel/logs/gateway.log 2>&1 &)
+  echo "[STARTED] gateway (log: .kestrel/logs/gateway.log)"
+
+  (cd "$ROOT_DIR" && nohup bash -lc "$KESTREL_WEB_CMD" > .kestrel/logs/web.log 2>&1 &)
+  echo "[STARTED] web (log: .kestrel/logs/web.log)"
+}
+
+case "$CMD" in
+  check)
+    run_checks
+    ;;
+  up)
+    run_checks
+    start_native_services
+    ;;
+  *)
+    echo "Usage: $0 [check|up]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
### Motivation

- Provide a documented desktop-first startup profile that launches Kestrel in native/hybrid mode with `screen-agent` enabled and native runtime selected. 
- Make Docker-heavy subsystems optional so users can run core services on the desktop while keeping heavy services (Postgres/Redis/Hands) in Docker when desired. 
- Ensure safe defaults that do not expose destructive host operations by disabling native host write/exec tools until an explicit policy is configured. 

### Description

- Added `config/startup/native-hybrid.env.example` which defines the native/hybrid profile flags (including `KESTREL_ENABLE_SCREEN_AGENT`, `KESTREL_ENABLE_DOCKER_SUBSYSTEMS`, `KESTREL_ENABLE_HOST_WRITE`, and `KESTREL_ENABLE_HOST_EXEC`) and example native start commands. 
- Added `scripts/startup/native-hybrid.sh` which implements `check` and `up` flow with preflight checks for dependencies, version guards, policy-file presence, repo permissions, and optional Docker subsystem startup. 
- Documented migration and usage in `docs/desktop-first-migration.md` and linked the quick-start steps from `README.md`. 
- Implemented safe registration gating in the Brain tool registry: `register_host_file_tools` now accepts `enable_write` and `register_host_execution_tools` accepts `enable_native_exec`, and the registry reads `KESTREL_ENABLE_HOST_WRITE` / `KESTREL_ENABLE_HOST_EXEC` to decide whether to register high-risk native tools. 

### Testing

- Ran `./scripts/startup/native-hybrid.sh check` against a profile copy with `KESTREL_ENABLE_DOCKER_SUBSYSTEMS=false` and received `[OK] Startup checks passed` for the environment used. 
- Ran the same `check` against the default profile and observed a helpful error when `docker` was missing, demonstrating the script detects required hybrid dependencies. 
- Compiled modified Python modules with `python -m compileall` for `packages/brain/agent/tools/__init__.py`, `host_files.py`, and `host_execution.py` to ensure there are no syntax errors. 

*Context improved by Giga AI: used AGENTS.md (main-overview) and `.cursor/rules/security-model.mdc` and `.cursor/rules/agent-architecture.mdc` to align startup safety defaults and architecture guidance.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc500278832aa03594474961a245)