### PR TITLE
Standardize action/event payloads for Brain tools and Hands audit pipeline

### DIFF
--- a/packages/brain/agent/evidence.py
+++ b/packages/brain/agent/evidence.py
@@ -16,11 +16,19 @@ No other agent provides this level of decision transparency.
 
 import json
 import logging
+import sys
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Any, Optional
+
+_SHARED_PATH = Path(__file__).resolve().parents[2] / "shared"
+if str(_SHARED_PATH) not in sys.path:
+    sys.path.append(str(_SHARED_PATH))
+
+from action_event_schema import normalize_action_event
 
 logger = logging.getLogger("brain.agent.evidence")
 
@@ -37,6 +45,7 @@ class EvidenceType(str, Enum):
     WEB_SEARCH = "web_search"           # From web search results
     PRIOR_DECISION = "prior_decision"   # Reference to an earlier decision
     HEURISTIC = "heuristic"             # Built-in rule or best practice
+    ACTION_EVENT = "action_event"       # Shared action/event payload references
 
 
 class DecisionType(str, Enum):
@@ -169,15 +178,37 @@ class EvidenceChain:
         alternatives: list[str] = None,
     ) -> DecisionRecord:
         """Convenience method for tool selection decisions."""
+        evidence_entries = [{
+            "type": "heuristic",
+            "content": f"Tool args: {json.dumps(args)[:300]}",
+            "source": "tool_registry",
+        }]
+
+        raw_events = []
+        if isinstance(args.get("action_event"), dict):
+            raw_events.append(args["action_event"])
+        if isinstance(args.get("action_events"), list):
+            raw_events.extend([e for e in args["action_events"] if isinstance(e, dict)])
+
+        for payload in raw_events:
+            event = normalize_action_event(payload)
+            refs = {
+                "before": event.get("before_state", {}),
+                "after": event.get("after_state", {}),
+                "status": event.get("status", ""),
+            }
+            evidence_entries.append({
+                "type": "action_event",
+                "content": json.dumps(refs)[:500],
+                "source": event.get("source", tool_name),
+                "relevance": 0.95,
+            })
+
         return self.record_decision(
             decision_type=DecisionType.TOOL_SELECTION,
             description=f"Selected tool: {tool_name}",
             reasoning=reasoning,
-            evidence=[{
-                "type": "heuristic",
-                "content": f"Tool args: {json.dumps(args)[:300]}",
-                "source": "tool_registry",
-            }],
+            evidence=evidence_entries,
             alternatives=[
                 {"tool": t, "reason_rejected": "Less suitable for current context"}
                 for t in (alternatives or [])

--- a/packages/brain/agent/tools/computer_use.py
+++ b/packages/brain/agent/tools/computer_use.py
@@ -36,12 +36,20 @@ import base64
 import json
 import logging
 import os
+import sys
 import time
+from pathlib import Path
 from typing import Any, Optional
 
 import httpx
 
 from agent.types import RiskLevel, ToolDefinition
+
+_SHARED_PATH = Path(__file__).resolve().parents[3] / "shared"
+if str(_SHARED_PATH) not in sys.path:
+    sys.path.append(str(_SHARED_PATH))
+
+from action_event_schema import build_action_event, stable_hash
 
 logger = logging.getLogger("brain.agent.tools.computer_use")
 
@@ -484,26 +492,67 @@ async def run_computer_use(
 
         # Execute each action via the screen agent
         function_responses = []
+        before_screenshot_hash = stable_hash(screenshot_b64)
         for action in actions:
             action_name = action["name"]
             action_args = action["args"]
+            command_hash = stable_hash(json.dumps({"action": action_name, "args": action_args}, sort_keys=True))
+            policy_decision = "auto_approved" if not action.get("needs_confirmation") else "confirmation_required"
 
             if action_name not in SUPPORTED_ACTIONS:
                 result_text = f"Unsupported action: {action_name}"
                 logger.warning(result_text)
+                status = "unsupported"
             else:
                 try:
                     result_text = await _execute_action(action_name, action_args)
                     logger.info(f"Executed: {result_text}")
+                    status = "success"
                 except Exception as e:
                     result_text = f"Action failed: {e}"
                     logger.error(result_text, exc_info=True)
+                    status = "failed"
+
+            # Capture post-action screenshot for reversible action history
+            try:
+                screenshot_bytes = await _capture_screenshot()
+                screenshot_b64 = base64.b64encode(screenshot_bytes).decode("utf-8")
+                after_screenshot_hash = stable_hash(screenshot_b64)
+            except RuntimeError as e:
+                return {
+                    "success": False,
+                    "error": f"Screenshot failed after action '{action_name}': {e}",
+                    "turns": turn + 1,
+                    "actions_taken": actions_taken,
+                    "model_commentary": "\n".join(commentary),
+                }
+
+            action_event = build_action_event(
+                source="brain.computer_use",
+                action_type=action_name,
+                status=status,
+                before_state={
+                    "screenshot_hash": before_screenshot_hash,
+                    "window_title": str(action_args.get("window_title", "")),
+                    "command_hash": command_hash,
+                    "policy_decision": policy_decision,
+                },
+                after_state={
+                    "screenshot_hash": after_screenshot_hash,
+                    "window_title": str(action_args.get("window_title", "")),
+                    "command_hash": command_hash,
+                    "policy_decision": "executed" if status == "success" else status,
+                },
+                metadata={"args": action_args, "turn": turn + 1, "result": result_text[:500]},
+            )
+            before_screenshot_hash = after_screenshot_hash
 
             actions_taken.append({
                 "action": action_name,
                 "args": action_args,
                 "result": result_text,
                 "turn": turn + 1,
+                "action_event": action_event,
             })
 
             function_responses.append({
@@ -515,20 +564,6 @@ async def run_computer_use(
 
         # Short pause for the UI to settle after actions
         await asyncio.sleep(0.5)
-
-        # Capture fresh screenshot after actions
-        try:
-            screenshot_bytes = await _capture_screenshot()
-        except RuntimeError as e:
-            return {
-                "success": False,
-                "error": f"Screenshot failed after actions: {e}",
-                "turns": turn + 1,
-                "actions_taken": actions_taken,
-                "model_commentary": "\n".join(commentary),
-            }
-
-        screenshot_b64 = base64.b64encode(screenshot_bytes).decode("utf-8")
 
         # Send function responses + new screenshot back to the model
         user_parts = function_responses + [

--- a/packages/brain/agent/tools/host_execution.py
+++ b/packages/brain/agent/tools/host_execution.py
@@ -9,12 +9,20 @@ import sys
 import asyncio
 import logging
 import tempfile
+import json
+from pathlib import Path
 from datetime import datetime
 from agent.types import RiskLevel, ToolDefinition
 
+_SHARED_PATH = Path(__file__).resolve().parents[3] / "shared"
+if str(_SHARED_PATH) not in sys.path:
+    sys.path.append(str(_SHARED_PATH))
+
+from action_event_schema import build_action_event, stable_hash
+
 logger = logging.getLogger("brain.agent.tools.host_execution")
 
-def _audit_log(command: str, language: str, approved: bool, error: str = ""):
+def _audit_log(command: str, language: str, approved: bool, error: str = "", action_event: dict | None = None):
     """Append execution attempts to the local audit log."""
     audit_dir = os.path.expanduser("~/.kestrel/audit")
     os.makedirs(audit_dir, exist_ok=True)
@@ -25,10 +33,16 @@ def _audit_log(command: str, language: str, approved: bool, error: str = ""):
     if error:
         status = f"FAILED ({error})"
         
-    log_entry = f"[{timestamp}] [{language}] [{status}] {command}\n"
+    log_entry = {
+        "timestamp": timestamp,
+        "language": language,
+        "status": status,
+        "command": command,
+        "action_event": action_event or {},
+    }
     try:
         with open(log_file, "a") as f:
-            f.write(log_entry)
+            f.write(json.dumps(log_entry) + "\n")
     except Exception as e:
         logger.error(f"Failed to write audit log: {e}")
 
@@ -89,6 +103,7 @@ def _check_allowlist(command: str) -> bool:
 
 async def execute_host_shell(command: str) -> dict:
     """Execute a shell command directly on the host OS."""
+    command_hash = stable_hash(command)
     
     # 1. Check Allowlist
     is_allowed = _check_allowlist(command)
@@ -97,15 +112,33 @@ async def execute_host_shell(command: str) -> dict:
     if not is_allowed:
         approved = await _prompt_mac_approval(command)
         if not approved:
-            _audit_log(command, "shell", approved=False)
+            action_event = build_action_event(
+                source="brain.host_execution",
+                action_type="host_shell",
+                status="denied",
+                before_state={"command_hash": command_hash, "policy_decision": "approval_required"},
+                after_state={"command_hash": command_hash, "policy_decision": "denied"},
+            )
+            _audit_log(command, "shell", approved=False, action_event=action_event)
             return {
                 "success": False,
                 "error": "User denied execution of high-risk command via native macOS dialog.",
-                "output": ""
+                "output": "",
+                "action_event": action_event,
             }
             
     # 3. Execute and audit
-    _audit_log(command, "shell", approved=True)
+    action_event = build_action_event(
+        source="brain.host_execution",
+        action_type="host_shell",
+        status="running",
+        before_state={
+            "command_hash": command_hash,
+            "policy_decision": "allowlist" if is_allowed else "user_approved",
+        },
+        after_state={"command_hash": command_hash, "policy_decision": "running"},
+    )
+    _audit_log(command, "shell", approved=True, action_event=action_event)
     try:
         proc = await asyncio.create_subprocess_shell(
             command,
@@ -113,18 +146,39 @@ async def execute_host_shell(command: str) -> dict:
             stderr=asyncio.subprocess.PIPE
         )
         stdout, stderr = await proc.communicate()
+        final_event = build_action_event(
+            source="brain.host_execution",
+            action_type="host_shell",
+            status="success" if proc.returncode == 0 else "failed",
+            before_state=action_event["before_state"],
+            after_state={
+                "command_hash": command_hash,
+                "policy_decision": "executed",
+            },
+            metadata={"exit_code": proc.returncode},
+        )
         return {
             "success": proc.returncode == 0,
             "output": stdout.decode(),
             "error": stderr.decode(),
-            "exit_code": proc.returncode
+            "exit_code": proc.returncode,
+            "action_event": final_event,
         }
     except Exception as e:
-        _audit_log(command, "shell", approved=True, error=str(e))
+        failed_event = build_action_event(
+            source="brain.host_execution",
+            action_type="host_shell",
+            status="failed",
+            before_state=action_event["before_state"],
+            after_state={"command_hash": command_hash, "policy_decision": "execution_error"},
+            metadata={"error": str(e)},
+        )
+        _audit_log(command, "shell", approved=True, error=str(e), action_event=failed_event)
         return {
             "success": False,
             "error": str(e),
-            "output": ""
+            "output": "",
+            "action_event": failed_event,
         }
 
 async def execute_host_python(code: str) -> dict:
@@ -134,16 +188,32 @@ async def execute_host_python(code: str) -> dict:
     # Always prompt for native approval for host python unless we build a complex analysis
     # For MVP, prompt approval for all raw python code
     
+    command_hash = stable_hash(code)
     approved = await _prompt_mac_approval("Python script with length: " + str(len(code)))
     if not approved:
-        _audit_log("Python Script", "python", approved=False)
+        denied_event = build_action_event(
+            source="brain.host_execution",
+            action_type="host_python",
+            status="denied",
+            before_state={"command_hash": command_hash, "policy_decision": "approval_required"},
+            after_state={"command_hash": command_hash, "policy_decision": "denied"},
+        )
+        _audit_log("Python Script", "python", approved=False, action_event=denied_event)
         return {
             "success": False,
             "error": "User denied execution of high-risk python code via native macOS dialog.",
-            "output": ""
+            "output": "",
+            "action_event": denied_event,
         }
 
-    _audit_log("Python Script", "python", approved=True)
+    running_event = build_action_event(
+        source="brain.host_execution",
+        action_type="host_python",
+        status="running",
+        before_state={"command_hash": command_hash, "policy_decision": "user_approved"},
+        after_state={"command_hash": command_hash, "policy_decision": "running"},
+    )
+    _audit_log("Python Script", "python", approved=True, action_event=running_event)
     tmp_path = None
     try:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -156,18 +226,36 @@ async def execute_host_python(code: str) -> dict:
             stderr=asyncio.subprocess.PIPE
         )
         stdout, stderr = await proc.communicate()
+        final_event = build_action_event(
+            source="brain.host_execution",
+            action_type="host_python",
+            status="success" if proc.returncode == 0 else "failed",
+            before_state=running_event["before_state"],
+            after_state={"command_hash": command_hash, "policy_decision": "executed"},
+            metadata={"exit_code": proc.returncode},
+        )
         return {
             "success": proc.returncode == 0,
             "output": stdout.decode(),
             "error": stderr.decode(),
-            "exit_code": proc.returncode
+            "exit_code": proc.returncode,
+            "action_event": final_event,
         }
     except Exception as e:
-        _audit_log("Python Script", "python", approved=True, error=str(e))
+        failed_event = build_action_event(
+            source="brain.host_execution",
+            action_type="host_python",
+            status="failed",
+            before_state=running_event["before_state"],
+            after_state={"command_hash": command_hash, "policy_decision": "execution_error"},
+            metadata={"error": str(e)},
+        )
+        _audit_log("Python Script", "python", approved=True, error=str(e), action_event=failed_event)
         return {
             "success": False,
             "error": str(e),
-            "output": ""
+            "output": "",
+            "action_event": failed_event,
         }
     finally:
         if tmp_path and os.path.exists(tmp_path):
@@ -224,3 +312,4 @@ def register_host_execution_tools(registry) -> None:
         ),
         handler=execute_host_python
     )
+    command_hash = stable_hash(command)

--- a/packages/brain/tests/test_evidence_action_event.py
+++ b/packages/brain/tests/test_evidence_action_event.py
@@ -1,0 +1,21 @@
+from agent.evidence import EvidenceChain
+
+
+def test_record_tool_decision_with_action_event_references():
+    chain = EvidenceChain(task_id="11111111-1111-1111-1111-111111111111")
+    decision = chain.record_tool_decision(
+        tool_name="computer_use",
+        args={
+            "action_event": {
+                "source": "brain.computer_use",
+                "action": "click_at",
+                "status": "success",
+                "before": {"command_hash": "abc", "policy_decision": "auto_approved"},
+                "after": {"command_hash": "abc", "policy_decision": "executed"},
+            }
+        },
+        reasoning="Need GUI interaction",
+    )
+
+    evidence_types = [item.evidence_type.value for item in decision.evidence]
+    assert "action_event" in evidence_types

--- a/packages/hands/security/audit.py
+++ b/packages/hands/security/audit.py
@@ -5,7 +5,15 @@ Audit logger — records all skill executions for accountability.
 import json
 import logging
 import os
+import sys
 from datetime import datetime
+from pathlib import Path
+
+_SHARED_PATH = Path(__file__).resolve().parents[2] / "shared"
+if str(_SHARED_PATH) not in sys.path:
+    sys.path.append(str(_SHARED_PATH))
+
+from action_event_schema import build_action_event, normalize_action_event, stable_hash
 
 logger = logging.getLogger("hands.security.audit")
 
@@ -25,15 +33,24 @@ class AuditLogger:
     def log_start(self, exec_id: str, user_id: str, workspace_id: str,
                   skill_name: str, function_name: str, arguments: str):
         """Log the start of a skill execution."""
+        command_hash = stable_hash(arguments)
+        start_event = build_action_event(
+            source="hands.security.audit",
+            action_type=f"{skill_name}.{function_name}",
+            status="running",
+            before_state={"command_hash": command_hash, "policy_decision": "admitted"},
+            after_state={"command_hash": command_hash, "policy_decision": "running"},
+        )
         entry = {
             "exec_id": exec_id,
             "user_id": user_id,
             "workspace_id": workspace_id,
             "skill_name": skill_name,
             "function_name": function_name,
-            "arguments_hash": hash(arguments),  # Don't log raw args for security
+            "arguments_hash": command_hash,  # Don't log raw args for security
             "started_at": datetime.utcnow().isoformat(),
             "status": "running",
+            "action_events": [start_event],
         }
         self._entries[exec_id] = entry
         logger.info(f"Audit: START {skill_name}.{function_name} [{exec_id[:8]}]")
@@ -57,6 +74,22 @@ class AuditLogger:
                 "file_accesses": len(audit_log.get("file_accesses", [])),
                 "system_calls": len(audit_log.get("system_calls", [])),
             }
+
+        completion_event = build_action_event(
+            source="hands.security.audit",
+            action_type=f"{entry.get('skill_name', '?')}.{entry.get('function_name', '?')}",
+            status=status,
+            before_state={
+                "command_hash": entry.get("arguments_hash", ""),
+                "policy_decision": "running",
+            },
+            after_state={
+                "command_hash": entry.get("arguments_hash", ""),
+                "policy_decision": status,
+            },
+            metadata={"error": error or "", "execution_time_ms": execution_time_ms},
+        )
+        entry.setdefault("action_events", []).append(normalize_action_event(completion_event))
 
         # Persist to file
         self._write_entry(entry)

--- a/packages/hands/server.py
+++ b/packages/hands/server.py
@@ -10,17 +10,24 @@ import logging
 import os
 import json
 import uuid
+import sys
+from pathlib import Path
 from concurrent import futures
 
 import grpc
 from grpc import aio as grpc_aio
 from dotenv import load_dotenv
 from grpc_tools import protoc
-import sys
 
 from executor import DockerExecutor
 from security.allowlist import PermissionChecker
 from security.audit import AuditLogger
+
+_SHARED_PATH = Path(__file__).resolve().parents[1] / "shared"
+if str(_SHARED_PATH) not in sys.path:
+    sys.path.append(str(_SHARED_PATH))
+
+from action_event_schema import build_action_event, dumps_action_event, stable_hash
 
 load_dotenv()
 logger = logging.getLogger("hands")
@@ -137,9 +144,18 @@ class HandsServicer:
                              function_name, arguments)
 
         # Yield RUNNING status
+        running_event = build_action_event(
+            source="hands.service",
+            action_type=f"{skill_name}.{function_name}",
+            status="running",
+            before_state={"command_hash": stable_hash(arguments), "policy_decision": "admitted"},
+            after_state={"command_hash": stable_hash(arguments), "policy_decision": "running"},
+            metadata={"exec_id": exec_id},
+        )
         yield hands_pb2.SkillExecutionResponse(
             status=hands_pb2.SkillExecutionResponse.Status.RUNNING,
             output=f"Executing {skill_name}.{function_name}...",
+            action_event_json=dumps_action_event(running_event),
         )
 
         try:
@@ -162,11 +178,24 @@ class HandsServicer:
             )
 
             audit_data = result.get("audit_log", {}) or {}
+            success_event = build_action_event(
+                source="hands.service",
+                action_type=f"{skill_name}.{function_name}",
+                status="success",
+                before_state={"command_hash": stable_hash(arguments), "policy_decision": "running"},
+                after_state={"command_hash": stable_hash(arguments), "policy_decision": "success"},
+                metadata={
+                    "exec_id": exec_id,
+                    "execution_time_ms": result.get("execution_time_ms", 0),
+                    "memory_used_mb": result.get("memory_used_mb", 0),
+                },
+            )
             yield hands_pb2.SkillExecutionResponse(
                 status=hands_pb2.SkillExecutionResponse.Status.SUCCESS,
                 output=result.get("output", ""),
                 execution_time_ms=result.get("execution_time_ms", 0),
                 memory_used_mb=result.get("memory_used_mb", 0),
+                action_event_json=dumps_action_event(success_event),
                 audit_log=hands_pb2.AuditLog(
                     network_requests=audit_data.get("network_requests", []),
                     file_accesses=audit_data.get("file_accesses", []),
@@ -177,16 +206,34 @@ class HandsServicer:
 
         except asyncio.TimeoutError:
             self.audit.log_complete(exec_id, status="timeout")
+            timeout_event = build_action_event(
+                source="hands.service",
+                action_type=f"{skill_name}.{function_name}",
+                status="timeout",
+                before_state={"command_hash": stable_hash(arguments), "policy_decision": "running"},
+                after_state={"command_hash": stable_hash(arguments), "policy_decision": "timeout"},
+                metadata={"exec_id": exec_id},
+            )
             yield hands_pb2.SkillExecutionResponse(
                 status=hands_pb2.SkillExecutionResponse.Status.TIMEOUT,
                 error=f"Skill execution timed out after {limits['timeout']}s",
+                action_event_json=dumps_action_event(timeout_event),
             )
 
         except Exception as e:
             self.audit.log_complete(exec_id, status="error", error=str(e))
+            error_event = build_action_event(
+                source="hands.service",
+                action_type=f"{skill_name}.{function_name}",
+                status="error",
+                before_state={"command_hash": stable_hash(arguments), "policy_decision": "running"},
+                after_state={"command_hash": stable_hash(arguments), "policy_decision": "error"},
+                metadata={"exec_id": exec_id, "error": str(e)},
+            )
             yield hands_pb2.SkillExecutionResponse(
                 status=hands_pb2.SkillExecutionResponse.Status.ERROR,
                 error=str(e),
+                action_event_json=dumps_action_event(error_event),
             )
 
     async def ListSkills(self, request, context):

--- a/packages/hands/tests/test_action_event_schema.py
+++ b/packages/hands/tests/test_action_event_schema.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+SHARED_PATH = Path(__file__).resolve().parents[2] / "shared"
+if str(SHARED_PATH) not in sys.path:
+    sys.path.append(str(SHARED_PATH))
+
+from action_event_schema import build_action_event, normalize_action_event, stable_hash
+
+
+def test_action_event_contains_reversible_state_references():
+    event = build_action_event(
+        source="hands.test",
+        action_type="demo.execute",
+        status="success",
+        before_state={"screenshot_hash": stable_hash("before"), "command_hash": stable_hash("cmd")},
+        after_state={"screenshot_hash": stable_hash("after"), "policy_decision": "success"},
+    )
+
+    normalized = normalize_action_event(event)
+    assert normalized["schema_version"] == "action_event.v1"
+    assert normalized["before_state"]["screenshot_hash"]
+    assert normalized["before_state"]["command_hash"]
+    assert normalized["after_state"]["policy_decision"] == "success"

--- a/packages/shared/action_event_schema.py
+++ b/packages/shared/action_event_schema.py
@@ -1,0 +1,76 @@
+"""Shared action/event schema for Brain and Hands execution traces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+SCHEMA_VERSION = "action_event.v1"
+
+
+def stable_hash(value: str) -> str:
+    """Return a deterministic SHA-256 hash for payload fingerprinting."""
+    return hashlib.sha256((value or "").encode("utf-8")).hexdigest()
+
+
+def make_state_reference(
+    *,
+    screenshot_hash: str = "",
+    window_title: str = "",
+    command_hash: str = "",
+    policy_decision: str = "",
+) -> dict[str, str]:
+    """Create standardized before/after state references for auditability."""
+    return {
+        "screenshot_hash": screenshot_hash or "",
+        "window_title": window_title or "",
+        "command_hash": command_hash or "",
+        "policy_decision": policy_decision or "",
+    }
+
+
+def build_action_event(
+    *,
+    source: str,
+    action_type: str,
+    status: str,
+    before_state: dict[str, str] | None = None,
+    after_state: dict[str, str] | None = None,
+    metadata: dict[str, Any] | None = None,
+    event_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a standardized action event payload."""
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": event_id or str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "action_type": action_type,
+        "status": status,
+        "before_state": make_state_reference(**(before_state or {})),
+        "after_state": make_state_reference(**(after_state or {})),
+        "metadata": metadata or {},
+    }
+    return payload
+
+
+def normalize_action_event(payload: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize an incoming payload to the shared action event schema."""
+    payload = payload or {}
+    return build_action_event(
+        source=str(payload.get("source", "unknown")),
+        action_type=str(payload.get("action_type", payload.get("action", "unknown"))),
+        status=str(payload.get("status", "unknown")),
+        before_state=payload.get("before_state") or payload.get("before") or {},
+        after_state=payload.get("after_state") or payload.get("after") or {},
+        metadata=payload.get("metadata") or {},
+        event_id=payload.get("event_id"),
+    )
+
+
+def dumps_action_event(payload: dict[str, Any]) -> str:
+    """Serialize standardized action events as compact JSON."""
+    return json.dumps(normalize_action_event(payload), separators=(",", ":"), sort_keys=True)

--- a/packages/shared/proto/hands.proto
+++ b/packages/shared/proto/hands.proto
@@ -57,6 +57,7 @@ message SkillExecutionResponse {
   int32 execution_time_ms = 4;
   int32 memory_used_mb = 5;
   AuditLog audit_log = 6;
+  string action_event_json = 7; // shared action/event schema payload
 }
 
 // Audit log for skill execution


### PR DESCRIPTION
### Motivation
- Provide a single, auditable action/event schema so Brain tools and the Hands audit pipeline record and exchange reversible state references consistently.
- Ensure per-action before/after state (screenshot hash, window title, command hash, policy decision) is captured so autonomous runs are reviewable and reversible.
- Bridge the new schema into existing evidence and audit systems to surface action context in decision traces and execution logs.

### Description
- Add a shared schema helper `packages/shared/action_event_schema.py` implementing `stable_hash`, `make_state_reference`, `build_action_event`, `normalize_action_event`, and `dumps_action_event` for `action_event.v1` payloads.
- Emit standardized action events from Brain tools: `packages/brain/agent/tools/computer_use.py` now records per-action event payloads with screenshot-hash transitions, window title, command hash, policy decision, and embeds `action_event` into `actions_taken`.
- Emit standardized action events from host execution paths: `packages/brain/agent/tools/host_execution.py` now builds `action_event` payloads for denied/running/success/failure flows and writes structured JSON audit lines to the local execution log.
- Integrate action events into evidence traces by adding `ACTION_EVENT` evidence type and normalizing `action_event`/`action_events` from tool args in `packages/brain/agent/evidence.py` so decision records include before/after references.
- Bridge into Hands auditing and transport: `packages/hands/security/audit.py` now uses deterministic `arguments_hash` and attaches start/completion `action_event`s to audit entries, and `packages/hands/server.py` includes `action_event_json` in `SkillExecutionResponse` for RUNNING/SUCCESS/TIMEOUT/ERROR responses; the protobuf `packages/shared/proto/hands.proto` was extended with `action_event_json`.
- Add focused unit tests `packages/hands/tests/test_action_event_schema.py` and `packages/brain/tests/test_evidence_action_event.py` validating schema normalization and evidence integration.

### Testing
- Ran Python syntax checks via `python -m py_compile` on all modified modules, which succeeded.
- Ran `pytest -q packages/hands/tests/test_permissions.py packages/hands/tests/test_skill_loader.py` with `9 passed` and `0 failed`.
- Ran `pytest -q packages/hands/tests/test_action_event_schema.py packages/brain/tests/test_evidence_action_event.py` with `2 passed` and `0 failed`.
- Ran combined targeted test suites and resolved an initial import ordering/test fixture issue during development; final focused test runs for the modified components passed.

*Context improved by Giga AI: used `.cursor/rules/agent-architecture.mdc` for evidence chain responsibilities, `.cursor/rules/data-flow.mdc` for Brain→Hands execution flow, and `.cursor/rules/security-model.mdc` for audit design decisions.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc43229c832a8f9bc01729610272)