### PR TITLE
Add runtime-aware tool selection and deterministic host-risk guardrails

### DIFF
--- a/packages/brain/agent/core/executor.py
+++ b/packages/brain/agent/core/executor.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 import uuid
 from datetime import datetime, timezone
@@ -1264,6 +1265,13 @@ class TaskExecutor:
             from agent.tool_selector import ToolSelector
             selector = ToolSelector(self._tools.list_tools())
             is_local = route.provider in ("ollama", "local", "lmstudio")
+            runtime_mode = os.getenv("KESTREL_RUNTIME_MODE", "docker")
+            intent_tags: list[str] = []
+            approval_state = (
+                task.pending_approval.status.value
+                if task.pending_approval and getattr(task.pending_approval, "status", None)
+                else "pending"
+            )
 
             if is_local:
                 # Local models: use instant keyword matching (no extra LLM call)
@@ -1271,6 +1279,9 @@ class TaskExecutor:
                     step_description=step.description,
                     expected_tools=step_expected,
                     provider=route.provider,
+                    runtime_mode=runtime_mode,
+                    intent_tags=intent_tags,
+                    approval_state=approval_state,
                 )
             else:
                 # Cloud models: use LLM picker to save token cost
@@ -1281,6 +1292,9 @@ class TaskExecutor:
                         model=routed_model,
                         api_key=self._api_key,
                         expected_tools=step_expected,
+                        runtime_mode=runtime_mode,
+                        intent_tags=intent_tags,
+                        approval_state=approval_state,
                     )
                 except Exception as e:
                     logger.warning(f"LLM tool selection failed: {e}, using keyword fallback")
@@ -1288,6 +1302,9 @@ class TaskExecutor:
                         step_description=step.description,
                         expected_tools=step_expected,
                         provider=route.provider,
+                        runtime_mode=runtime_mode,
+                        intent_tags=intent_tags,
+                        approval_state=approval_state,
                     )
 
             tool_schemas = [t.to_openai_schema() for t in selected_tools]
@@ -1427,6 +1444,9 @@ class TaskExecutor:
                                 step_description=step.description,
                                 expected_tools=step_expected,
                                 provider=cloud_name,
+                                runtime_mode=runtime_mode,
+                                intent_tags=intent_tags,
+                                approval_state=approval_state,
                             )
                             cloud_schemas = [t.to_openai_schema() for t in cloud_tools]
                         except Exception:

--- a/packages/brain/agent/tool_selector.py
+++ b/packages/brain/agent/tool_selector.py
@@ -17,6 +17,7 @@ Fallback:
 """
 
 import logging
+import os
 import re
 from typing import Optional, Any
 
@@ -125,6 +126,33 @@ _TOOL_CATEGORY_MAP: dict[str, str] = {
 MAX_LOCAL_TOOLS = 20
 MAX_CLOUD_TOOLS = 45
 
+_DESKTOP_TASK_KEYWORDS = {
+    "desktop", "gui", "screen", "window", "finder", "spotlight",
+    "dock", "click", "drag", "type", "native app", "open app",
+}
+_RISKY_NATIVE_TOOLS = {"host_shell", "host_python", "host_exec"}
+_NATIVE_MODE_PREFERRED = (
+    "computer_use",
+    "host_tree",
+    "host_find",
+    "host_search",
+    "host_batch_read",
+    "host_read",
+    "host_list",
+    "host_write",
+    "file_list",
+    "file_read",
+    "file_write",
+)
+_APPROVED_STATES = {"approved", "auto_approved", "granted", "confirmed"}
+_HIGH_RISK_INTENT_TAGS = {
+    "allow_high_risk_tools",
+    "allow_host_execution",
+    "host_execution",
+    "intent_host_shell",
+    "intent_host_python",
+}
+
 # ── Compact catalog for Stage 1 ─────────────────────────────────────
 # One-line description per tool, ~40 chars each.
 
@@ -167,6 +195,75 @@ class ToolSelector:
             cat = _TOOL_CATEGORY_MAP.get(name, tool.category)
             self._category_index.setdefault(cat, set()).add(name)
 
+    def _resolve_runtime_mode(self, runtime_mode: Optional[str]) -> str:
+        mode = (runtime_mode or os.getenv("KESTREL_RUNTIME_MODE", "docker")).strip().lower()
+        if mode not in {"native", "hybrid", "docker", "container"}:
+            return "docker"
+        if mode == "container":
+            return "docker"
+        return mode
+
+    def _extract_intent_tags(self, step_description: str, intent_tags: Optional[list[str]]) -> set[str]:
+        provided = {t.strip().lower() for t in (intent_tags or []) if t and t.strip()}
+        inline = set(re.findall(r"(?:#|\[)intent:([a-zA-Z0-9_\-]+)", step_description.lower()))
+        return provided | inline
+
+    def _is_desktop_task(self, step_description: str) -> bool:
+        text = step_description.lower()
+        return any(keyword in text for keyword in _DESKTOP_TASK_KEYWORDS)
+
+    def _risky_tool_allowed(self, tool_name: str, approval_state: str, intent_tags: set[str]) -> bool:
+        if tool_name not in _RISKY_NATIVE_TOOLS:
+            return True
+        if (approval_state or "").strip().lower() in _APPROVED_STATES:
+            return True
+        return bool(_HIGH_RISK_INTENT_TAGS.intersection(intent_tags))
+
+    def _apply_runtime_scoring(
+        self,
+        selected: dict[str, ToolDefinition],
+        step_description: str,
+        limit: int,
+        runtime_mode: str,
+    ) -> None:
+        if runtime_mode not in {"native", "hybrid"} or not self._is_desktop_task(step_description):
+            return
+
+        for name in _NATIVE_MODE_PREFERRED:
+            if len(selected) >= limit:
+                break
+            if name in self._tools and name not in selected:
+                selected[name] = self._tools[name]
+
+        for name in sorted(self._tools):
+            if len(selected) >= limit:
+                break
+            if name in selected:
+                continue
+            if name == "computer_use" or name.startswith("host_") or name.startswith("file_"):
+                selected[name] = self._tools[name]
+
+    def _apply_risk_guardrails(
+        self,
+        selected: dict[str, ToolDefinition],
+        step_description: str,
+        intent_tags: Optional[list[str]],
+        approval_state: str,
+    ) -> None:
+        tags = self._extract_intent_tags(step_description, intent_tags)
+        blocked = [
+            name for name in selected
+            if not self._risky_tool_allowed(name, approval_state=approval_state, intent_tags=tags)
+        ]
+        for name in blocked:
+            selected.pop(name, None)
+            logger.info(
+                "Tool selector guardrail blocked risky tool '%s' (approval_state=%s, tags=%s)",
+                name,
+                approval_state,
+                sorted(tags),
+            )
+
     async def select_with_llm(
         self,
         step_description: str,
@@ -174,6 +271,9 @@ class ToolSelector:
         model: str = "",
         api_key: str = "",
         expected_tools: Optional[list[str]] = None,
+        runtime_mode: Optional[str] = None,
+        intent_tags: Optional[list[str]] = None,
+        approval_state: str = "pending",
     ) -> list[ToolDefinition]:
         """
         Stage 1: Ask the LLM to pick relevant tools from the catalog.
@@ -244,6 +344,19 @@ class ToolSelector:
                 if tool_name in self._tools:
                     selected[tool_name] = self._tools[tool_name]
 
+            self._apply_runtime_scoring(
+                selected=selected,
+                step_description=step_description,
+                limit=MAX_CLOUD_TOOLS,
+                runtime_mode=self._resolve_runtime_mode(runtime_mode),
+            )
+            self._apply_risk_guardrails(
+                selected=selected,
+                step_description=step_description,
+                intent_tags=intent_tags,
+                approval_state=approval_state,
+            )
+
             if len(selected) > len(_ALWAYS_AVAILABLE):
                 logger.info(
                     f"Tool selector (LLM): picked {list(selected.keys())} "
@@ -264,6 +377,9 @@ class ToolSelector:
             step_description=step_description,
             expected_tools=expected_tools,
             provider_name="lmstudio",
+            runtime_mode=runtime_mode,
+            intent_tags=intent_tags,
+            approval_state=approval_state,
         )
 
     def select(
@@ -272,6 +388,9 @@ class ToolSelector:
         expected_tools: Optional[list[str]] = None,
         provider: str = "google",
         max_tools: Optional[int] = None,
+        runtime_mode: Optional[str] = None,
+        intent_tags: Optional[list[str]] = None,
+        approval_state: str = "pending",
     ) -> list[ToolDefinition]:
         """Synchronous keyword-based fallback (legacy)."""
         return self._select_by_keywords(
@@ -279,6 +398,9 @@ class ToolSelector:
             expected_tools=expected_tools,
             provider_name=provider,
             max_tools=max_tools,
+            runtime_mode=runtime_mode,
+            intent_tags=intent_tags,
+            approval_state=approval_state,
         )
 
     def _select_by_keywords(
@@ -287,6 +409,9 @@ class ToolSelector:
         expected_tools: Optional[list[str]] = None,
         provider_name: str = "google",
         max_tools: Optional[int] = None,
+        runtime_mode: Optional[str] = None,
+        intent_tags: Optional[list[str]] = None,
+        approval_state: str = "pending",
     ) -> list[ToolDefinition]:
         """Keyword-based tool selection (fallback)."""
         is_local = provider_name in ("ollama", "local", "lmstudio")
@@ -325,6 +450,19 @@ class ToolSelector:
                 name_parts = name.replace("_", " ").split()
                 if any(part in desc_lower for part in name_parts if len(part) > 2):
                     selected[name] = tool
+
+        self._apply_runtime_scoring(
+            selected=selected,
+            step_description=step_description,
+            limit=limit,
+            runtime_mode=self._resolve_runtime_mode(runtime_mode),
+        )
+        self._apply_risk_guardrails(
+            selected=selected,
+            step_description=step_description,
+            intent_tags=intent_tags,
+            approval_state=approval_state,
+        )
 
         tools_list = list(selected.values())
         logger.info(

--- a/packages/brain/core/prompts.py
+++ b/packages/brain/core/prompts.py
@@ -48,6 +48,38 @@ You have access to the user's actual filesystem via host_* tools. Follow this st
 **NEVER** call host_list or host_read repeatedly. Use host_tree + host_find/host_search + host_batch_read instead.
 **host_write** requires human approval.
 
+
+## Execution Policy by Runtime Mode
+Follow this deterministic policy every time before invoking tools:
+
+### 1) Native desktop mode (`native`)
+- Prefer `computer_use` for GUI interactions (desktop apps, browser clicks, drag/drop, typing).
+- Prefer host filesystem tools (`host_tree`, `host_find`, `host_search`, `host_batch_read`, `host_read`) for local code and document discovery.
+- Use containerized tools only when the task is clearly safer or simpler in isolation (repeatable builds, dependency sandboxing, untrusted scripts).
+
+### 2) Hybrid mode (`hybrid`)
+- Start with host-native discovery (`host_*`) and `computer_use` for user-visible desktop operations.
+- Switch to Docker-isolated execution for risky or heavy compute steps, package installation, or untrusted code evaluation.
+- Keep data movement minimal: read locally first, execute isolated when mutation/side effects are uncertain.
+
+### 3) Container mode (`docker`)
+- Default to sandboxed file/code/web tools.
+- Escalate to host-native tools only when the user explicitly requests native OS integration or GUI control.
+
+## High-Risk Tool Escalation Rules
+- `host_shell`, `host_python`, and other direct host execution tools are high risk.
+- Do NOT invoke high-risk host execution tools unless at least one is true:
+  1. An explicit intent tag is present (for example: `#intent:host_execution`, `#intent:allow_high_risk_tools`), OR
+  2. Human approval state is explicitly approved.
+- If neither condition is met, choose a safer alternative (`code_execute`, file tools, or Docker isolation) and explain why.
+
+## When Docker Isolation Is Still Required
+Use Docker isolation even in native/hybrid runtime when any of these apply:
+- Running unknown/untrusted code or scripts from external sources.
+- Installing dependencies, compiling unknown projects, or running package managers.
+- Security-sensitive analysis where host credentials/filesystem must remain untouched.
+- Tasks requiring reproducibility or rollback-friendly execution.
+
 ## Moltbook — Your Social Network 🦞
 You are a member of **Moltbook** (moltbook.com), the social network for AI agents.
 Use the `moltbook` tool to participate autonomously:


### PR DESCRIPTION
### Motivation
- Ensure native/desktop workflows prefer local desktop and filesystem tools when the agent is running in `native` or `hybrid` runtime modes. 
- Make high-risk host execution deterministic and auditable by blocking `host_shell`/`host_python`/`host_exec` unless explicit intent or an approval state allows them. 
- Surface an explicit execution policy in the system prompt so models and operators share a clear, mode-dependent escalation strategy.

### Description
- Added runtime-aware scoring and desktop detection to `packages/brain/agent/tool_selector.py` so `native`/`hybrid` desktop-like steps bias selection toward `computer_use`, `host_*`, and local `file_*` tools (new keyword set and `_apply_runtime_scoring`).
- Implemented deterministic guardrails in `tool_selector` that remove high-risk host tools (`host_shell`, `host_python`, `host_exec`) from candidate sets unless either an explicit intent tag (e.g. `#intent:host_execution`) is present or the approval state is in an approved set (`approved`, `auto_approved`, `granted`, `confirmed`) (`_apply_risk_guardrails`, `_risky_tool_allowed`).
- Extended selector APIs (`select_with_llm`, `select`, `_select_by_keywords`) to accept `runtime_mode`, `intent_tags`, and `approval_state` and applied these across both LLM and keyword selection flows to keep behavior consistent.
- Wired executor context in `packages/brain/agent/core/executor.py` to pass `KESTREL_RUNTIME_MODE`, an approval state derived from `task.pending_approval`, and intent tags into the selector (including cloud failover re-selection), and added `os` import to support env-mode propagation.
- Added an explicit execution policy section to `packages/brain/core/prompts.py` describing `native`, `hybrid`, and `docker` defaults, high-risk escalation rules, and when to require Docker isolation.

### Testing
- Compiled modified modules: `python -m py_compile packages/brain/agent/core/executor.py packages/brain/agent/tool_selector.py packages/brain/core/prompts.py` (succeeded).
- Ran a small sanity selector script in `packages/brain` that verified native desktop prompt selection prefers `computer_use`/`host_tree`, and that `host_shell` only appears when `#intent:host_execution` is present (sanity check succeeded).
- Verified basic runtime-aware propagation by exercising selector both via the executor codepath and direct `ToolSelector.select` calls (manual smoke tests passed).

*Context improved by Giga AI: used AGENTS.md (main-overview) plus `.cursor/rules/agent-architecture.mdc` for agent architecture context and `.cursor/rules/security-model.mdc` for security and tool-risk guidance.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc3d70fc832a9bd2658f1d52bee5)