### PR TITLE
Enhance screen-agent introspection and verified action retries

### DIFF
--- a/packages/brain/agent/tools/computer_use.py
+++ b/packages/brain/agent/tools/computer_use.py
@@ -1,4 +1,3 @@
-from typing import Optional
 """
 Gemini Computer Use — Desktop control via Gemini's Computer Use model.
 
@@ -33,10 +32,10 @@ Coordinate system:
 
 import asyncio
 import base64
-import json
 import logging
 import os
 import time
+import uuid
 from typing import Any, Optional
 
 import httpx
@@ -97,6 +96,8 @@ async def _resolve_computer_use_model() -> str:
 
 # Host-side screen agent URL (runs natively on the Mac)
 SCREEN_AGENT_URL = os.getenv("SCREEN_AGENT_URL", "http://host.docker.internal:9800")
+ACTION_VERIFY_RETRIES = int(os.getenv("COMPUTER_USE_ACTION_VERIFY_RETRIES", "2"))
+ACTION_RETRY_DELAY_SECONDS = float(os.getenv("COMPUTER_USE_ACTION_RETRY_DELAY_SECONDS", "1.0"))
 
 # Actions the model can request
 SUPPORTED_ACTIONS = {
@@ -145,28 +146,64 @@ async def _capture_screenshot() -> bytes:
         raise RuntimeError("Screen agent timed out capturing screenshot")
 
 
-async def _execute_action(action_name: str, args: dict) -> str:
-    """
-    Send an action to the host-side screen agent for execution.
-    Returns a human-readable description of what was done.
-    """
+async def _post_screen_agent(path: str, payload: Optional[dict] = None, timeout: float = 30.0) -> dict:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(f"{SCREEN_AGENT_URL}{path}", json=payload or {})
+        if resp.status_code != 200:
+            raise RuntimeError(f"Screen agent {path} failed ({resp.status_code}): {resp.text[:200]}")
+        return resp.json()
+
+
+def _expected_state_from_action(action_name: str, args: dict) -> dict[str, str]:
+    expected: dict[str, str] = {}
+    if action_name in {"navigate", "open_url"} and args.get("url"):
+        expected["url_contains"] = str(args["url"])
+    if action_name == "type_text_at" and args.get("text"):
+        expected["text_contains"] = str(args["text"])[:80]
+    if args.get("expect_app"):
+        expected["app"] = str(args["expect_app"])
+    if args.get("expect_window"):
+        expected["window_title"] = str(args["expect_window"])
+    if args.get("expect_url_contains"):
+        expected["url_contains"] = str(args["expect_url_contains"])
+    if args.get("expect_text"):
+        expected["text_contains"] = str(args["expect_text"])
+    return expected
+
+
+async def _verify_expected_state(expected: dict[str, str]) -> dict[str, Any]:
+    if not expected:
+        return {"passed": True, "checks": {}, "context": {}, "reason": "no_expectations"}
+
+    validation = await _post_screen_agent("/validate", payload=expected, timeout=45.0)
+    if validation.get("success"):
+        return {
+            "passed": validation.get("passed", False),
+            "checks": validation.get("checks", {}),
+            "context": validation.get("context", {}),
+        }
+    return {"passed": False, "checks": {}, "context": {}, "reason": "validation_call_failed"}
+
+
+async def _execute_action(action_name: str, args: dict, idempotency_key: str) -> dict[str, Any]:
+    payload = {"action": action_name, "args": args, "idempotency_key": idempotency_key}
     try:
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.post(
-                f"{SCREEN_AGENT_URL}/action",
-                json={"action": action_name, "args": args},
-            )
-            if resp.status_code != 200:
-                return f"Screen agent error ({resp.status_code}): {resp.text[:200]}"
-            data = resp.json()
-            if data.get("success"):
-                return data.get("result", "Action completed")
-            else:
-                return f"Action failed: {data.get('error', 'unknown')}"
+        data = await _post_screen_agent("/action", payload=payload, timeout=40.0)
     except httpx.ConnectError:
-        return "ERROR: Cannot connect to screen agent"
+        return {"success": False, "result": "", "error": "ERROR: Cannot connect to screen agent"}
     except httpx.TimeoutException:
-        return "ERROR: Screen agent timed out"
+        return {"success": False, "result": "", "error": "ERROR: Screen agent timed out"}
+    except Exception as exc:
+        return {"success": False, "result": "", "error": str(exc)}
+
+    return {
+        "success": data.get("success", False),
+        "result": data.get("result", ""),
+        "error": data.get("error", ""),
+        "action_id": data.get("action_id", ""),
+        "replayed": data.get("replayed", False),
+        "validation": data.get("validation", {}),
+    }
 
 
 # ── Gemini API Interaction ───────────────────────────────────────────
@@ -378,6 +415,8 @@ async def run_computer_use(
     default_system = (
         "You are controlling a desktop computer to accomplish the user's goal. "
         "Observe the screenshot carefully. Take one action at a time. "
+        "When useful, include expectation hints in function args using "
+        "expect_app, expect_window, expect_url_contains, expect_text so actions can be verified. "
         "When the goal is accomplished, respond with text only (no function calls) "
         "summarizing what you did."
     )
@@ -487,29 +526,73 @@ async def run_computer_use(
         for action in actions:
             action_name = action["name"]
             action_args = action["args"]
+            expected_state = _expected_state_from_action(action_name, action_args)
+            attempt_records: list[dict[str, Any]] = []
 
             if action_name not in SUPPORTED_ACTIONS:
                 result_text = f"Unsupported action: {action_name}"
+                verification = {"passed": False, "reason": "unsupported_action"}
                 logger.warning(result_text)
             else:
-                try:
-                    result_text = await _execute_action(action_name, action_args)
-                    logger.info(f"Executed: {result_text}")
-                except Exception as e:
-                    result_text = f"Action failed: {e}"
-                    logger.error(result_text, exc_info=True)
+                verification = {"passed": True, "reason": "not_checked"}
+                result_text = ""
+                for attempt in range(ACTION_VERIFY_RETRIES + 1):
+                    action_key = f"turn-{turn + 1}:{action_name}:{uuid.uuid4()}"
+                    execution = await _execute_action(action_name, action_args, action_key)
+                    attempt_record = {
+                        "attempt": attempt + 1,
+                        "execution": execution,
+                    }
+
+                    if not execution.get("success"):
+                        result_text = f"Action failed: {execution.get('error', 'unknown')}"
+                        attempt_record["verification"] = {
+                            "passed": False,
+                            "reason": "execution_error",
+                        }
+                        attempt_records.append(attempt_record)
+                    else:
+                        result_text = execution.get("result", "Action completed")
+                        logger.info(f"Executed: {result_text}")
+                        await asyncio.sleep(0.35)
+                        verification = await _verify_expected_state(expected_state)
+                        attempt_record["verification"] = verification
+                        attempt_records.append(attempt_record)
+                        if verification.get("passed"):
+                            break
+                        if attempt < ACTION_VERIFY_RETRIES:
+                            await asyncio.sleep(ACTION_RETRY_DELAY_SECONDS)
+                            continue
+                        result_text = (
+                            f"Action completed but verification failed: {verification.get('checks', {})}"
+                        )
+                    if attempt < ACTION_VERIFY_RETRIES:
+                        await asyncio.sleep(ACTION_RETRY_DELAY_SECONDS)
+                if expected_state and not verification.get("passed"):
+                    logger.warning(
+                        "UI transition appears stale after retries for %s; expected=%s",
+                        action_name,
+                        expected_state,
+                    )
 
             actions_taken.append({
                 "action": action_name,
                 "args": action_args,
                 "result": result_text,
+                "expected_state": expected_state,
+                "verification": verification,
+                "attempts": attempt_records,
                 "turn": turn + 1,
             })
 
             function_responses.append({
                 "functionResponse": {
                     "name": action_name,
-                    "response": {"result": result_text},
+                    "response": {
+                        "result": result_text,
+                        "expected_state": expected_state,
+                        "verification": verification,
+                    },
                 }
             })
 

--- a/packages/screen-agent/screen_agent.py
+++ b/packages/screen-agent/screen_agent.py
@@ -13,13 +13,26 @@ Usage:
 import base64
 import io
 import logging
+import os
+import subprocess
 import time
+import uuid
+from threading import Lock
 from typing import Any, Optional
 
 import pyautogui
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
+try:
+    import pytesseract
+except Exception:  # pragma: no cover - optional dependency
+    pytesseract = None
+
+try:
+    import pygetwindow as gw
+except Exception:  # pragma: no cover - optional dependency
+    gw = None
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
 logger = logging.getLogger("screen-agent")
@@ -42,12 +55,60 @@ pyautogui.FAILSAFE = True  # Move mouse to corner to abort
 class ActionRequest(BaseModel):
     action: str
     args: dict[str, Any] = {}
+    idempotency_key: Optional[str] = None
 
 
 class ActionResponse(BaseModel):
     success: bool
     result: str = ""
     error: str = ""
+    action_id: str = ""
+    replayed: bool = False
+    validation: dict[str, Any] = {}
+
+
+class OCRRequest(BaseModel):
+    region: Optional[dict[str, int]] = None
+    needle: Optional[str] = None
+
+
+class ValidationRequest(BaseModel):
+    app: Optional[str] = None
+    window_title: Optional[str] = None
+    url_contains: Optional[str] = None
+    text_contains: Optional[str] = None
+
+
+class UIElementsRequest(BaseModel):
+    provider: str = "none"
+    options: dict[str, Any] = {}
+
+
+ACTION_RESULT_CACHE: dict[str, dict[str, Any]] = {}
+ACTION_CACHE_LOCK = Lock()
+ACTION_CACHE_TTL_SECONDS = int(os.getenv("SCREEN_AGENT_ACTION_CACHE_TTL_SECONDS", "600"))
+
+
+def _cache_set(key: str, value: dict[str, Any]) -> None:
+    with ACTION_CACHE_LOCK:
+        ACTION_RESULT_CACHE[key] = {"ts": time.time(), "value": value}
+
+
+def _cache_get(key: str) -> Optional[dict[str, Any]]:
+    now = time.time()
+    with ACTION_CACHE_LOCK:
+        expired = [
+            cache_key
+            for cache_key, entry in ACTION_RESULT_CACHE.items()
+            if now - entry["ts"] > ACTION_CACHE_TTL_SECONDS
+        ]
+        for cache_key in expired:
+            ACTION_RESULT_CACHE.pop(cache_key, None)
+
+        entry = ACTION_RESULT_CACHE.get(key)
+        if not entry:
+            return None
+        return entry["value"]
 
 
 # ── Coordinate Helpers ───────────────────────────────────────────────
@@ -161,6 +222,125 @@ def execute_action(action_name: str, args: dict) -> str:
         return f"Unknown action: {action_name}"
 
 
+def _run_osascript(script: str) -> str:
+    try:
+        output = subprocess.check_output(["osascript", "-e", script], text=True)
+        return output.strip()
+    except Exception:
+        return ""
+
+
+def _active_context() -> dict[str, str]:
+    app_name = ""
+    window_title = ""
+    current_url = ""
+
+    if gw is not None:
+        try:
+            active_window = gw.getActiveWindow()
+            if active_window:
+                window_title = getattr(active_window, "title", "") or ""
+        except Exception:
+            pass
+
+    app_name = _run_osascript(
+        'tell application "System Events" to get name of first application process whose frontmost is true'
+    )
+    if not window_title:
+        window_title = _run_osascript(
+            'tell application "System Events" to tell (first application process whose frontmost is true) to get name of front window'
+        )
+
+    if app_name == "Safari":
+        current_url = _run_osascript('tell application "Safari" to return URL of front document')
+    elif app_name == "Google Chrome":
+        current_url = _run_osascript('tell application "Google Chrome" to return URL of active tab of front window')
+
+    return {
+        "app": app_name,
+        "window_title": window_title,
+        "url": current_url,
+    }
+
+
+def _capture_screen_image(region: Optional[dict[str, int]] = None):
+    if region:
+        left = max(0, region.get("left", 0))
+        top = max(0, region.get("top", 0))
+        width = max(1, region.get("width", SCREEN_WIDTH))
+        height = max(1, region.get("height", SCREEN_HEIGHT))
+        return pyautogui.screenshot(region=(left, top, width, height))
+    return pyautogui.screenshot()
+
+
+def _run_ocr(region: Optional[dict[str, int]] = None) -> dict[str, Any]:
+    if pytesseract is None:
+        return {
+            "success": False,
+            "error": "pytesseract not available in screen-agent environment",
+            "text": "",
+        }
+
+    image = _capture_screen_image(region)
+    text = pytesseract.image_to_string(image)
+    return {
+        "success": True,
+        "text": text,
+        "char_count": len(text),
+    }
+
+
+def _validate_expectations(expectations: ValidationRequest) -> dict[str, Any]:
+    checks: dict[str, Any] = {}
+    context = _active_context()
+
+    if expectations.app:
+        expected = expectations.app.lower()
+        actual = context.get("app", "")
+        checks["app"] = {
+            "expected": expectations.app,
+            "actual": actual,
+            "ok": expected in actual.lower(),
+        }
+
+    if expectations.window_title:
+        expected = expectations.window_title.lower()
+        actual = context.get("window_title", "")
+        checks["window_title"] = {
+            "expected": expectations.window_title,
+            "actual": actual,
+            "ok": expected in actual.lower(),
+        }
+
+    if expectations.url_contains:
+        expected = expectations.url_contains.lower()
+        actual = context.get("url", "")
+        checks["url_contains"] = {
+            "expected": expectations.url_contains,
+            "actual": actual,
+            "ok": expected in actual.lower(),
+        }
+
+    if expectations.text_contains:
+        ocr_result = _run_ocr()
+        actual_text = ocr_result.get("text", "") if ocr_result.get("success") else ""
+        expected = expectations.text_contains.lower()
+        checks["text_contains"] = {
+            "expected": expectations.text_contains,
+            "actual_excerpt": actual_text[:500],
+            "ok": expected in actual_text.lower(),
+            "ocr_success": ocr_result.get("success", False),
+            "ocr_error": ocr_result.get("error", ""),
+        }
+
+    passed = all(item.get("ok", False) for item in checks.values()) if checks else True
+    return {
+        "passed": passed,
+        "checks": checks,
+        "context": context,
+    }
+
+
 # ── Endpoints ────────────────────────────────────────────────────────
 
 
@@ -184,16 +364,92 @@ async def screenshot():
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@app.get("/active_window")
+async def active_window():
+    try:
+        return {"success": True, **_active_context()}
+    except Exception as e:
+        logger.error(f"Active window introspection failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/ocr")
+async def ocr(req: OCRRequest):
+    try:
+        result = _run_ocr(req.region)
+        if req.needle and result.get("success"):
+            text = result.get("text", "")
+            result["contains_needle"] = req.needle.lower() in text.lower()
+        return result
+    except Exception as e:
+        logger.error(f"OCR failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/detect_ui_elements")
+async def detect_ui_elements(req: UIElementsRequest):
+    """
+    Optional UI element detection hook.
+    Integrators can replace this with a provider-backed implementation.
+    """
+    return {
+        "success": False,
+        "provider": req.provider,
+        "elements": [],
+        "error": "No UI element detector configured",
+    }
+
+
+@app.post("/validate")
+async def validate(req: ValidationRequest):
+    try:
+        return {"success": True, **_validate_expectations(req)}
+    except Exception as e:
+        logger.error(f"Validation failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @app.post("/action", response_model=ActionResponse)
 async def perform_action(req: ActionRequest):
     """Execute a desktop action via PyAutoGUI."""
+    action_id = req.idempotency_key or str(uuid.uuid4())
+
+    cached = _cache_get(action_id)
+    if cached:
+        return ActionResponse(
+            success=cached.get("success", False),
+            result=cached.get("result", ""),
+            error=cached.get("error", ""),
+            validation=cached.get("validation", {}),
+            action_id=action_id,
+            replayed=True,
+        )
+
     try:
         result = execute_action(req.action, req.args)
         logger.info(f"Action: {req.action} -> {result}")
-        return ActionResponse(success=True, result=result)
+        validation = {}
+        validate_args = req.args.get("validate")
+        if isinstance(validate_args, dict):
+            validation = _validate_expectations(ValidationRequest(**validate_args))
+        response = {
+            "success": True,
+            "result": result,
+            "error": "",
+            "validation": validation,
+        }
+        _cache_set(action_id, response)
+        return ActionResponse(**response, action_id=action_id)
     except Exception as e:
         logger.error(f"Action failed: {req.action} — {e}", exc_info=True)
-        return ActionResponse(success=False, error=str(e))
+        response = {
+            "success": False,
+            "result": "",
+            "error": str(e),
+            "validation": {},
+        }
+        _cache_set(action_id, response)
+        return ActionResponse(**response, action_id=action_id)
 
 
 # ── Entry Point ──────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Improve reliability of automated desktop actions by adding host-side introspection (active app/window/url) and OCR so actions can be validated after execution. 
- Provide optional UI element detection hooks and idempotent action replay to avoid duplicate work and enable safe replays. 
- Surface verification primitives to the Brain's `computer_use` tool so the agent can confirm expected UI transitions and apply bounded retry/fallback when transitions are stale.

### Description
- Extended `packages/screen-agent/screen_agent.py` with new endpoints and primitives: `GET /active_window` for app/window/url inspection, `POST /ocr` for on-screen text extraction (needle matching), `POST /detect_ui_elements` as a pluggable detection hook, and `POST /validate` for expectation checks across app/window/url/text, plus optional `pytesseract`/`pygetwindow` usage with graceful degradation. 
- Added idempotency support and in-memory TTL cache to `/action` via `ActionRequest.idempotency_key`, and expanded `ActionResponse` with `action_id`, `replayed`, and `validation` fields so callers can detect replays and view validation details. 
- Updated `packages/brain/agent/tools/computer_use.py` to use the richer screen-agent surface: introduced `_post_screen_agent`, `_expected_state_from_action`, and `_verify_expected_state` helpers, forward per-action idempotency keys, derive expected post-action state (app/window/url/text), and run bounded verification + retry/fallback loops when verification fails or transitions look stale. 
- Captured per-attempt telemetry in `actions_taken` and model function responses (including attempts, execution results, and verification checks), and updated the system prompt guidance to encourage expectation hints (`expect_app`, `expect_window`, `expect_url_contains`, `expect_text`).

### Testing
- Compiled modified modules with `python -m compileall packages/screen-agent/screen_agent.py packages/brain/agent/tools/computer_use.py` and the compilation succeeded.

*Context improved by Giga AI: I used AGENTS.md (development guidelines and scope) and `.cursor/rules/agent-architecture.mdc` (agent architecture components) and `.cursor/rules/data-flow.mdc` (tool execution and data flow) to align changes with verification and evidence-chain expectations.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc362940832aa8fde3b12c514f75)