### PR TITLE
Refactor host execution to use native policy evaluator and shared audit vocabulary

### DIFF
--- a/packages/brain/agent/security/__init__.py
+++ b/packages/brain/agent/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security primitives for agent-native execution."""

--- a/packages/brain/agent/security/native_policy.py
+++ b/packages/brain/agent/security/native_policy.py
@@ -1,0 +1,280 @@
+"""Native execution policy evaluation and approval providers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import platform
+import re
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+logger = logging.getLogger("brain.agent.security.native_policy")
+
+
+@dataclass(frozen=True)
+class NativeExecutionRequest:
+    workspace_id: str
+    tool_name: str
+    function_name: str
+    command: str
+    command_class: str
+    interactive: bool = False
+
+
+@dataclass(frozen=True)
+class ApprovalResult:
+    approved: bool
+    reason: str
+    provider: str
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    reason: str
+    requires_approval: bool = False
+
+
+class ApprovalProvider(Protocol):
+    async def approve(self, request: NativeExecutionRequest) -> ApprovalResult:
+        """Return an approval decision for this request."""
+
+
+class NonInteractiveApprovalProvider:
+    """Approval provider for headless execution environments."""
+
+    def __init__(self, mode: str = "deny"):
+        self.mode = mode
+
+    async def approve(self, request: NativeExecutionRequest) -> ApprovalResult:
+        approved = self.mode == "allow"
+        reason = (
+            "AUTO_APPROVED_NON_INTERACTIVE"
+            if approved
+            else "DENIED_NON_INTERACTIVE"
+        )
+        return ApprovalResult(
+            approved=approved,
+            reason=reason,
+            provider=f"non_interactive:{self.mode}",
+        )
+
+
+class MacOSDialogApprovalProvider:
+    """Interactive approval provider backed by osascript on macOS."""
+
+    async def approve(self, request: NativeExecutionRequest) -> ApprovalResult:
+        if platform.system().lower() != "darwin":
+            return ApprovalResult(
+                approved=False,
+                reason="INTERACTIVE_PROVIDER_UNAVAILABLE",
+                provider="macos_dialog",
+            )
+
+        safe_command = request.command.replace('"', '\\"')
+        if len(safe_command) > 150:
+            safe_command = safe_command[:147] + "..."
+
+        script = f'''
+        try
+            set dialogResult to display dialog "Kestrel Agent OS is requesting to natively execute:\\n\\n{safe_command}" buttons {{"Deny", "Approve"}} default button "Deny" with icon caution with title "Security Authorization"
+            if button returned of dialogResult is "Approve" then
+                return "true"
+            else
+                return "false"
+            end if
+        on error number -128
+            return "false"
+        end try
+        '''
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "osascript",
+                "-e",
+                script,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            approved = stdout.decode().strip() == "true"
+            return ApprovalResult(
+                approved=approved,
+                reason=("APPROVED_INTERACTIVE" if approved else "DENIED_INTERACTIVE"),
+                provider="macos_dialog",
+            )
+        except Exception as exc:  # pragma: no cover - subprocess failures are env-specific
+            logger.error("macOS approval dialog failed: %s", exc)
+            return ApprovalResult(
+                approved=False,
+                reason="INTERACTIVE_PROVIDER_ERROR",
+                provider="macos_dialog",
+            )
+
+
+@dataclass
+class WorkspaceNativePolicy:
+    mode: str = "allow_all"
+    command_classes: list[str] = field(default_factory=list)
+    rules: list[dict[str, Any]] = field(default_factory=list)
+
+
+class NativePolicyEvaluator:
+    """Workspace-scoped policy evaluator for native execution requests."""
+
+    _DANGEROUS_RE = re.compile(
+        r"(\brm\b\s+-rf|\bshutdown\b|\breboot\b|\bmkfs\b|\bdd\b|\bchmod\b\s+777|\bsudo\b)",
+        re.IGNORECASE,
+    )
+    _NETWORK_RE = re.compile(r"\b(curl|wget|nc|ncat|ssh|scp)\b", re.IGNORECASE)
+    _READ_ONLY_RE = re.compile(r"^\s*(ls|cat|pwd|echo|which|whoami|date|id)\b", re.IGNORECASE)
+
+    def __init__(self):
+        self._workspace_policies: dict[str, WorkspaceNativePolicy] = {}
+
+    def set_policy(self, workspace_id: str, policy: dict[str, Any]) -> None:
+        self._workspace_policies[workspace_id] = WorkspaceNativePolicy(
+            mode=policy.get("mode", "allow_all"),
+            command_classes=policy.get("command_classes", []),
+            rules=policy.get("rules", []),
+        )
+
+    def get_policy(self, workspace_id: str) -> WorkspaceNativePolicy | None:
+        policy = self._workspace_policies.get(workspace_id)
+        if policy:
+            return policy
+
+        allowed_patterns = self._load_legacy_allowlist_patterns()
+        if not allowed_patterns:
+            return None
+
+        return WorkspaceNativePolicy(
+            mode="allowlist",
+            rules=[
+                {"effect": "allow", "pattern": pattern, "command_classes": ["shell"]}
+                for pattern in allowed_patterns
+            ],
+        )
+
+    def classify(self, tool_name: str, payload: str) -> str:
+        if tool_name == "host_python":
+            return "code"
+
+        if self._DANGEROUS_RE.search(payload):
+            return "destructive"
+        if self._NETWORK_RE.search(payload):
+            return "network"
+        if self._READ_ONLY_RE.search(payload):
+            return "read_only"
+        return "shell"
+
+    def evaluate(self, request: NativeExecutionRequest) -> PolicyDecision:
+        policy = self.get_policy(request.workspace_id)
+        if policy is None:
+            return PolicyDecision(
+                allowed=True,
+                reason="NO_WORKSPACE_POLICY",
+                requires_approval=request.command_class != "read_only",
+            )
+
+        rule_decision = self._evaluate_rules(policy, request)
+        if rule_decision is not None:
+            return rule_decision
+
+        if policy.command_classes:
+            if policy.mode == "allowlist":
+                allowed = request.command_class in policy.command_classes
+                return PolicyDecision(
+                    allowed=allowed,
+                    reason="ALLOWLIST_COMMAND_CLASS",
+                    requires_approval=allowed and request.command_class != "read_only",
+                )
+
+            if policy.mode == "blocklist":
+                allowed = request.command_class not in policy.command_classes
+                return PolicyDecision(
+                    allowed=allowed,
+                    reason="BLOCKLIST_COMMAND_CLASS",
+                    requires_approval=allowed and request.command_class != "read_only",
+                )
+
+        return PolicyDecision(
+            allowed=True,
+            reason=f"POLICY_MODE_{policy.mode.upper()}",
+            requires_approval=request.command_class != "read_only",
+        )
+
+    def _evaluate_rules(
+        self,
+        policy: WorkspaceNativePolicy,
+        request: NativeExecutionRequest,
+    ) -> PolicyDecision | None:
+        for rule in policy.rules:
+            pattern = rule.get("pattern")
+            if not pattern:
+                continue
+
+            try:
+                if not re.search(pattern, request.command):
+                    continue
+            except re.error:
+                logger.warning("Invalid native policy regex pattern: %s", pattern)
+                continue
+
+            classes = rule.get("command_classes", [])
+            if classes and request.command_class not in classes:
+                continue
+
+            effect = rule.get("effect", "deny")
+            if effect == "allow":
+                return PolicyDecision(
+                    allowed=True,
+                    reason="ALLOW_RULE_MATCH",
+                    requires_approval=request.command_class != "read_only",
+                )
+
+            return PolicyDecision(allowed=False, reason="DENY_RULE_MATCH")
+
+        return None
+
+    @staticmethod
+    def _load_legacy_allowlist_patterns() -> list[str]:
+        allowlist_path = os.path.expanduser("~/.kestrel/allowlist.yml")
+        if not os.path.exists(allowlist_path):
+            return []
+
+        try:
+            import yaml
+
+            with open(allowlist_path, "r", encoding="utf-8") as file_handle:
+                config = yaml.safe_load(file_handle) or {}
+                patterns = config.get("allowed_commands", [])
+                return [pattern for pattern in patterns if isinstance(pattern, str)]
+        except Exception as exc:
+            logger.warning("Error reading native legacy allowlist: %s", exc)
+            return []
+
+
+def make_default_approval_provider(interactive: bool) -> ApprovalProvider:
+    if interactive:
+        return MacOSDialogApprovalProvider()
+
+    mode = os.getenv("NATIVE_APPROVAL_NON_INTERACTIVE_MODE", "deny").strip().lower()
+    if mode not in {"allow", "deny"}:
+        mode = "deny"
+    return NonInteractiveApprovalProvider(mode=mode)
+
+
+DEFAULT_NATIVE_POLICY_EVALUATOR = NativePolicyEvaluator()
+
+
+def set_workspace_native_policy(workspace_id: str, policy: dict[str, Any]) -> None:
+    """Register/update workspace native execution policy."""
+    DEFAULT_NATIVE_POLICY_EVALUATOR.set_policy(workspace_id, policy)
+
+
+def get_workspace_native_policy(workspace_id: str) -> WorkspaceNativePolicy | None:
+    """Get workspace native execution policy."""
+    return DEFAULT_NATIVE_POLICY_EVALUATOR.get_policy(workspace_id)

--- a/packages/brain/agent/tools/host_execution.py
+++ b/packages/brain/agent/tools/host_execution.py
@@ -1,173 +1,289 @@
 """
-Host Execution Tools — Native shell/python execution on the host macOS.
-WARNING: These tools bypass the container isolation and execute directly
-on the host machine. Regulated by an allowlist and native macOS approval dialogs.
+Host Execution Tools — Native shell/python execution on the host OS.
+WARNING: These tools bypass container isolation and execute directly on host.
+Policy decisions and approval are delegated to native policy evaluators/providers.
 """
 
+import asyncio
+import json
+import logging
 import os
 import sys
-import asyncio
-import logging
 import tempfile
+import uuid
 from datetime import datetime
+
+from agent.security.native_policy import (
+    NativeExecutionRequest,
+    DEFAULT_NATIVE_POLICY_EVALUATOR,
+    make_default_approval_provider,
+)
 from agent.types import RiskLevel, ToolDefinition
 
 logger = logging.getLogger("brain.agent.tools.host_execution")
 
-def _audit_log(command: str, language: str, approved: bool, error: str = ""):
-    """Append execution attempts to the local audit log."""
+_POLICY_EVALUATOR = DEFAULT_NATIVE_POLICY_EVALUATOR
+
+
+def _audit_log(
+    *,
+    exec_id: str,
+    workspace_id: str,
+    user_id: str,
+    tool_name: str,
+    function_name: str,
+    arguments: str,
+    status: str,
+    policy_reason: str,
+    approval_provider: str,
+    approval_reason: str,
+    started_at: datetime,
+    error: str = "",
+    exit_code: int | None = None,
+):
+    """Write native execution audit entries using hands-compatible schema concepts."""
     audit_dir = os.path.expanduser("~/.kestrel/audit")
     os.makedirs(audit_dir, exist_ok=True)
-    log_file = os.path.join(audit_dir, "execution.log")
-    
-    timestamp = datetime.now().isoformat()
-    status = "APPROVED" if approved else "DENIED"
+    log_file = os.path.join(audit_dir, f"audit-{datetime.utcnow().strftime('%Y-%m-%d')}.jsonl")
+
+    elapsed_ms = int((datetime.utcnow() - started_at).total_seconds() * 1000)
+
+    entry = {
+        "exec_id": exec_id,
+        "user_id": user_id,
+        "workspace_id": workspace_id,
+        "skill_name": tool_name,
+        "function_name": function_name,
+        "arguments_hash": hash(arguments),
+        "started_at": started_at.isoformat(),
+        "completed_at": datetime.utcnow().isoformat(),
+        "status": status,
+        "execution_time_ms": elapsed_ms,
+        "native_policy": {
+            "policy_reason": policy_reason,
+            "approval_provider": approval_provider,
+            "approval_reason": approval_reason,
+        },
+    }
     if error:
-        status = f"FAILED ({error})"
-        
-    log_entry = f"[{timestamp}] [{language}] [{status}] {command}\n"
-    try:
-        with open(log_file, "a") as f:
-            f.write(log_entry)
-    except Exception as e:
-        logger.error(f"Failed to write audit log: {e}")
+        entry["error"] = error
+    if exit_code is not None:
+        entry["exit_code"] = exit_code
 
-async def _prompt_mac_approval(command: str) -> bool:
-    """Prompt the user for approval using macOS native dialog via osascript."""
-    safe_command = command.replace('"', '\\"')
-    if len(safe_command) > 150:
-         safe_command = safe_command[:147] + "..."
-         
-    script = f'''
-    try
-        set dialogResult to display dialog "Kestrel Agent OS is requesting to natively execute:\\n\\n{safe_command}" buttons {{"Deny", "Approve"}} default button "Deny" with icon caution with title "Security Authorization"
-        if button returned of dialogResult is "Approve" then
-            return "true"
-        else
-            return "false"
-        end if
-    on error number -128
-        return "false"
-    end try
-    '''
-    
     try:
-        proc = await asyncio.create_subprocess_exec(
-            "osascript", "-e", script,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
-        )
-        stdout, _ = await proc.communicate()
-        result = stdout.decode().strip()
-        return result == "true"
-    except Exception as e:
-        logger.error(f"macOS approval dialog failed: {e}")
-        return False
+        with open(log_file, "a", encoding="utf-8") as file_handle:
+            file_handle.write(json.dumps(entry) + "\n")
+    except Exception as exc:  # pragma: no cover - file system issues are env-specific
+        logger.error("Failed to write audit log: %s", exc)
 
-def _check_allowlist(command: str) -> bool:
-    """Check if a command matches the allowlist in ~/.kestrel/allowlist.yml"""
-    allowlist_path = os.path.expanduser("~/.kestrel/allowlist.yml")
-    if not os.path.exists(allowlist_path):
-        return False
-        
-    try:
-        import yaml
-        import re
-        with open(allowlist_path, "r") as f:
-            config = yaml.safe_load(f) or {}
-            allowed_patterns = config.get("allowed_commands", [])
-            for pattern in allowed_patterns:
-                try:
-                    if re.search(pattern, command):
-                        return True
-                except re.error as re_err:
-                    logger.warning(f"Invalid allowlist regex pattern '{pattern}': {re_err}")
-    except Exception as e:
-        logger.warning(f"Error reading allowlist: {e}")
-        
-    return False
+
+async def _authorize_native_execution(tool_name: str, command: str) -> tuple[bool, str, str, str]:
+    workspace_id = os.getenv("KESTREL_WORKSPACE_ID", "default")
+    interactive = os.getenv("NATIVE_APPROVAL_INTERACTIVE", "false").lower() == "true"
+
+    request = NativeExecutionRequest(
+        workspace_id=workspace_id,
+        tool_name=tool_name,
+        function_name="execute",
+        command=command,
+        command_class=_POLICY_EVALUATOR.classify(tool_name, command),
+        interactive=interactive,
+    )
+
+    decision = _POLICY_EVALUATOR.evaluate(request)
+    if not decision.allowed:
+        return False, decision.reason, "policy", "DENIED_BY_POLICY"
+
+    if not decision.requires_approval:
+        return True, decision.reason, "policy", "NOT_REQUIRED"
+
+    provider = make_default_approval_provider(interactive=interactive)
+    approval = await provider.approve(request)
+    return approval.approved, decision.reason, approval.provider, approval.reason
+
 
 async def execute_host_shell(command: str) -> dict:
     """Execute a shell command directly on the host OS."""
-    
-    # 1. Check Allowlist
-    is_allowed = _check_allowlist(command)
-    
-    # 2. If not in allowlist, prompt for local approval
-    if not is_allowed:
-        approved = await _prompt_mac_approval(command)
-        if not approved:
-            _audit_log(command, "shell", approved=False)
-            return {
-                "success": False,
-                "error": "User denied execution of high-risk command via native macOS dialog.",
-                "output": ""
-            }
-            
-    # 3. Execute and audit
-    _audit_log(command, "shell", approved=True)
+    started_at = datetime.utcnow()
+    exec_id = str(uuid.uuid4())
+    workspace_id = os.getenv("KESTREL_WORKSPACE_ID", "default")
+    user_id = os.getenv("KESTREL_USER_ID", "agent")
+
+    approved, policy_reason, approval_provider, approval_reason = await _authorize_native_execution(
+        "host_shell",
+        command,
+    )
+    if not approved:
+        _audit_log(
+            exec_id=exec_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            tool_name="host_execution",
+            function_name="host_shell",
+            arguments=command,
+            status="denied",
+            policy_reason=policy_reason,
+            approval_provider=approval_provider,
+            approval_reason=approval_reason,
+            started_at=started_at,
+            error="Native shell execution denied by policy/approval",
+        )
+        return {
+            "success": False,
+            "error": "Native shell execution denied by policy/approval.",
+            "output": "",
+            "policy_reason": policy_reason,
+            "approval_reason": approval_reason,
+        }
+
     try:
         proc = await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
+            stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await proc.communicate()
+        status = "success" if proc.returncode == 0 else "error"
+        _audit_log(
+            exec_id=exec_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            tool_name="host_execution",
+            function_name="host_shell",
+            arguments=command,
+            status=status,
+            policy_reason=policy_reason,
+            approval_provider=approval_provider,
+            approval_reason=approval_reason,
+            started_at=started_at,
+            error=stderr.decode() if proc.returncode != 0 else "",
+            exit_code=proc.returncode,
+        )
         return {
             "success": proc.returncode == 0,
             "output": stdout.decode(),
             "error": stderr.decode(),
-            "exit_code": proc.returncode
+            "exit_code": proc.returncode,
+            "policy_reason": policy_reason,
+            "approval_reason": approval_reason,
         }
-    except Exception as e:
-        _audit_log(command, "shell", approved=True, error=str(e))
+    except Exception as exc:
+        _audit_log(
+            exec_id=exec_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            tool_name="host_execution",
+            function_name="host_shell",
+            arguments=command,
+            status="error",
+            policy_reason=policy_reason,
+            approval_provider=approval_provider,
+            approval_reason=approval_reason,
+            started_at=started_at,
+            error=str(exc),
+        )
         return {
             "success": False,
-            "error": str(e),
-            "output": ""
+            "error": str(exc),
+            "output": "",
+            "policy_reason": policy_reason,
+            "approval_reason": approval_reason,
         }
+
 
 async def execute_host_python(code: str) -> dict:
     """Execute python code directly on the host OS."""
-    
-    # We serialize the code to a temporary file and run `python3 cache_file.py`
-    # Always prompt for native approval for host python unless we build a complex analysis
-    # For MVP, prompt approval for all raw python code
-    
-    approved = await _prompt_mac_approval("Python script with length: " + str(len(code)))
+    started_at = datetime.utcnow()
+    exec_id = str(uuid.uuid4())
+    workspace_id = os.getenv("KESTREL_WORKSPACE_ID", "default")
+    user_id = os.getenv("KESTREL_USER_ID", "agent")
+
+    command_preview = f"python(script_length={len(code)})"
+    approved, policy_reason, approval_provider, approval_reason = await _authorize_native_execution(
+        "host_python",
+        command_preview,
+    )
     if not approved:
-        _audit_log("Python Script", "python", approved=False)
+        _audit_log(
+            exec_id=exec_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            tool_name="host_execution",
+            function_name="host_python",
+            arguments=command_preview,
+            status="denied",
+            policy_reason=policy_reason,
+            approval_provider=approval_provider,
+            approval_reason=approval_reason,
+            started_at=started_at,
+            error="Native python execution denied by policy/approval",
+        )
         return {
             "success": False,
-            "error": "User denied execution of high-risk python code via native macOS dialog.",
-            "output": ""
+            "error": "Native python execution denied by policy/approval.",
+            "output": "",
+            "policy_reason": policy_reason,
+            "approval_reason": approval_reason,
         }
 
-    _audit_log("Python Script", "python", approved=True)
     tmp_path = None
     try:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(code)
-            tmp_path = f.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as file_handle:
+            file_handle.write(code)
+            tmp_path = file_handle.name
 
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, tmp_path,
+            sys.executable,
+            tmp_path,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
+            stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await proc.communicate()
+        status = "success" if proc.returncode == 0 else "error"
+        _audit_log(
+            exec_id=exec_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            tool_name="host_execution",
+            function_name="host_python",
+            arguments=command_preview,
+            status=status,
+            policy_reason=policy_reason,
+            approval_provider=approval_provider,
+            approval_reason=approval_reason,
+            started_at=started_at,
+            error=stderr.decode() if proc.returncode != 0 else "",
+            exit_code=proc.returncode,
+        )
         return {
             "success": proc.returncode == 0,
             "output": stdout.decode(),
             "error": stderr.decode(),
-            "exit_code": proc.returncode
+            "exit_code": proc.returncode,
+            "policy_reason": policy_reason,
+            "approval_reason": approval_reason,
         }
-    except Exception as e:
-        _audit_log("Python Script", "python", approved=True, error=str(e))
+    except Exception as exc:
+        _audit_log(
+            exec_id=exec_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            tool_name="host_execution",
+            function_name="host_python",
+            arguments=command_preview,
+            status="error",
+            policy_reason=policy_reason,
+            approval_provider=approval_provider,
+            approval_reason=approval_reason,
+            started_at=started_at,
+            error=str(exc),
+        )
         return {
             "success": False,
-            "error": str(e),
-            "output": ""
+            "error": str(exc),
+            "output": "",
+            "policy_reason": policy_reason,
+            "approval_reason": approval_reason,
         }
     finally:
         if tmp_path and os.path.exists(tmp_path):
@@ -176,51 +292,52 @@ async def execute_host_python(code: str) -> dict:
             except Exception:
                 pass
 
+
 def register_host_execution_tools(registry) -> None:
     registry.register(
         definition=ToolDefinition(
             name="host_shell",
             description=(
-                "Execute a shell command DIRECTLY on the host macOS. "
-                "Use this for tasks that require native OS access. "
-                "WARNING: High risk. Commands not in the allowlist will trigger a native popup dialog."
+                "Execute a shell command DIRECTLY on the host OS. "
+                "Uses workspace-scoped native policy evaluation and approval providers. "
+                "WARNING: High risk operation."
             ),
             parameters={
                 "type": "object",
                 "properties": {
                     "command": {
                         "type": "string",
-                        "description": "The shell command to execute"
+                        "description": "The shell command to execute",
                     }
                 },
-                "required": ["command"]
+                "required": ["command"],
             },
             risk_level=RiskLevel.HIGH,
-            category="control"
+            category="control",
         ),
-        handler=execute_host_shell
+        handler=execute_host_shell,
     )
-    
+
     registry.register(
         definition=ToolDefinition(
             name="host_python",
             description=(
-                "Execute Python code DIRECTLY on the host macOS. "
-                "Allows the agent to use host resources, credentials, and modules. "
-                "WARNING: High risk. Will trigger a native popup dialog for authorization."
+                "Execute Python code DIRECTLY on the host OS. "
+                "Uses workspace-scoped native policy evaluation and approval providers. "
+                "WARNING: High risk operation."
             ),
             parameters={
                 "type": "object",
                 "properties": {
                     "code": {
                         "type": "string",
-                        "description": "The python code to execute"
+                        "description": "The python code to execute",
                     }
                 },
-                "required": ["code"]
+                "required": ["code"],
             },
             risk_level=RiskLevel.HIGH,
-            category="control"
+            category="control",
         ),
-        handler=execute_host_python
+        handler=execute_host_python,
     )

--- a/packages/brain/tests/test_native_policy.py
+++ b/packages/brain/tests/test_native_policy.py
@@ -1,0 +1,59 @@
+import pytest
+
+from agent.security.native_policy import (
+    NativeExecutionRequest,
+    NativePolicyEvaluator,
+    NonInteractiveApprovalProvider,
+)
+
+
+def test_classifies_commands():
+    evaluator = NativePolicyEvaluator()
+
+    assert evaluator.classify("host_shell", "ls -la") == "read_only"
+    assert evaluator.classify("host_shell", "curl https://example.com") == "network"
+    assert evaluator.classify("host_shell", "rm -rf /tmp/x") == "destructive"
+    assert evaluator.classify("host_python", "print('x')") == "code"
+
+
+def test_workspace_allowlist_command_classes():
+    evaluator = NativePolicyEvaluator()
+    evaluator.set_policy(
+        "ws-1",
+        {"mode": "allowlist", "command_classes": ["read_only"]},
+    )
+
+    read_req = NativeExecutionRequest(
+        workspace_id="ws-1",
+        tool_name="host_shell",
+        function_name="execute",
+        command="ls",
+        command_class="read_only",
+    )
+    write_req = NativeExecutionRequest(
+        workspace_id="ws-1",
+        tool_name="host_shell",
+        function_name="execute",
+        command="echo hi > a.txt",
+        command_class="shell",
+    )
+
+    assert evaluator.evaluate(read_req).allowed is True
+    assert evaluator.evaluate(write_req).allowed is False
+
+
+@pytest.mark.asyncio
+async def test_non_interactive_provider_modes():
+    req = NativeExecutionRequest(
+        workspace_id="ws",
+        tool_name="host_shell",
+        function_name="execute",
+        command="ls",
+        command_class="read_only",
+    )
+
+    deny = await NonInteractiveApprovalProvider(mode="deny").approve(req)
+    allow = await NonInteractiveApprovalProvider(mode="allow").approve(req)
+
+    assert deny.approved is False
+    assert allow.approved is True


### PR DESCRIPTION
### Motivation
- Remove direct macOS dialog and local allowlist coupling from native host execution tool logic to make approval behavior pluggable and platform-agnostic.
- Unify native execution policy and audit vocabulary with existing Hands security concepts (workspace-scoped policies and audit schema).
- Support both interactive and headless environments via pluggable approval providers so native and container execution share the same policy surface.

### Description
- Added `packages/brain/agent/security/native_policy.py` implementing `NativePolicyEvaluator`, command-class classification, regex rule evaluation, and approval providers (`MacOSDialogApprovalProvider` and `NonInteractiveApprovalProvider`).
- Refactored `packages/brain/agent/tools/host_execution.py` to delegate authorization to the policy evaluator and approval providers, removing direct `osascript` and inline allowlist checks.
- Replaced legacy host audit logging with JSONL entries that use Hands-compatible fields (`exec_id`, `workspace_id`, `skill_name`, `function_name`, `status`, timing, `error`) and include native policy metadata.
- Added global helpers to register workspace native policies and a test module `packages/brain/tests/test_native_policy.py` covering classification, workspace allowlist rules, and non-interactive approval modes.

### Testing
- Ran unit tests: `pytest -q packages/brain/tests/test_native_policy.py` (3 passed).
- Verified syntax: `python -m py_compile packages/brain/agent/security/native_policy.py packages/brain/agent/tools/host_execution.py` (no errors).
- Confirmed files added and updated: `packages/brain/agent/security/native_policy.py`, `packages/brain/agent/security/__init__.py`, `packages/brain/agent/tools/host_execution.py`, and `packages/brain/tests/test_native_policy.py`.

*Context improved by Giga AI: I used workspace security and audit guidance from `.cursor/rules/security-model.mdc` and the development guidelines and instructions from `AGENTS.md` to scope and design the policy evaluator and audit alignment.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc329e9c832ab5013ccb5c1d264c)