### PR TITLE
Introduce runtime policy abstraction for execution tools

### DIFF
--- a/packages/brain/agent/runtime/__init__.py
+++ b/packages/brain/agent/runtime/__init__.py
@@ -1,0 +1,22 @@
+"""Agent runtime policy package."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from agent.runtime.base import ExecutionRuntime
+from agent.runtime.policy import build_runtime_policy
+
+_active_runtime: Optional[ExecutionRuntime] = None
+
+
+def set_active_runtime(runtime: Optional[ExecutionRuntime]) -> None:
+    global _active_runtime
+    _active_runtime = runtime
+
+
+def get_active_runtime() -> Optional[ExecutionRuntime]:
+    return _active_runtime
+
+
+__all__ = ["build_runtime_policy", "set_active_runtime", "get_active_runtime"]

--- a/packages/brain/agent/runtime/base.py
+++ b/packages/brain/agent/runtime/base.py
@@ -1,0 +1,62 @@
+"""Runtime abstraction for agent execution environments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Protocol
+
+
+class RuntimeMode(str, Enum):
+    """Supported runtime profiles."""
+
+    DOCKER = "docker"
+    NATIVE = "native"
+    HYBRID = "hybrid"
+
+
+@dataclass(frozen=True)
+class RuntimeCapabilities:
+    """Capability flags exposed to tools and policy checks."""
+
+    mode: RuntimeMode
+    supports_docker_execution: bool = False
+    supports_native_execution: bool = False
+    supports_computer_use: bool = False
+    supports_host_shell: bool = False
+    supports_host_python: bool = False
+    supports_code_languages: tuple[str, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize capabilities for tool responses and logging."""
+        return {
+            "mode": self.mode.value,
+            "supports_docker_execution": self.supports_docker_execution,
+            "supports_native_execution": self.supports_native_execution,
+            "supports_computer_use": self.supports_computer_use,
+            "supports_host_shell": self.supports_host_shell,
+            "supports_host_python": self.supports_host_python,
+            "supports_code_languages": list(self.supports_code_languages),
+        }
+
+
+class ExecutionRuntime(Protocol):
+    """Common execute() contract for runtime backends."""
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        ...
+
+    async def execute(
+        self,
+        *,
+        tool_name: str,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        ...
+
+
+class RuntimeErrorResult(Exception):
+    """Raised for policy/runtime resolution errors."""
+
+    pass

--- a/packages/brain/agent/runtime/docker_runtime.py
+++ b/packages/brain/agent/runtime/docker_runtime.py
@@ -1,0 +1,83 @@
+"""Docker/Hands runtime backend."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Mapping
+
+from agent.runtime.base import RuntimeCapabilities, RuntimeErrorResult, RuntimeMode
+
+logger = logging.getLogger("brain.agent.runtime.docker")
+
+
+class DockerRuntime:
+    """Execute supported tool actions via Hands running in container runtime."""
+
+    def __init__(self, hands_client: Any = None):
+        self._hands_client = hands_client
+        self._capabilities = RuntimeCapabilities(
+            mode=RuntimeMode.DOCKER,
+            supports_docker_execution=hands_client is not None,
+            supports_code_languages=("python", "javascript", "shell"),
+        )
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        return self._capabilities
+
+    async def execute(self, *, tool_name: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        if tool_name != "code_execute":
+            raise RuntimeErrorResult(f"Docker runtime does not handle tool: {tool_name}")
+
+        if not self._hands_client:
+            return {
+                "success": False,
+                "error": (
+                    "Code execution requires the Hands service for secure sandboxing. "
+                    "The Hands service is not connected."
+                ),
+            }
+
+        language = str(payload.get("language", "python"))
+        code = str(payload.get("code", ""))
+        timeout = int(payload.get("timeout", 30))
+
+        import hands_pb2
+
+        skill_map = {
+            "python": "python_executor",
+            "javascript": "node_executor",
+            "shell": "shell_executor",
+        }
+        request = hands_pb2.SkillExecutionRequest(
+            skill_name=skill_map.get(language, "python_executor"),
+            function_name="run",
+            arguments=json.dumps({"code": code}),
+            limits=hands_pb2.ResourceLimits(
+                timeout_seconds=timeout,
+                memory_mb=512,
+                network_enabled=True,
+            ),
+        )
+
+        output_parts: list[str] = []
+        error_parts: list[str] = []
+        status = "RUNNING"
+        exec_time = 0
+
+        async for chunk in self._hands_client.ExecuteSkill(request):
+            if chunk.output:
+                output_parts.append(chunk.output)
+            if chunk.error:
+                error_parts.append(chunk.error)
+            if chunk.execution_time_ms:
+                exec_time = chunk.execution_time_ms
+            status = hands_pb2.SkillExecutionResponse.Status.Name(chunk.status)
+
+        return {
+            "success": status == "SUCCESS",
+            "output": "".join(output_parts),
+            "error": "".join(error_parts),
+            "execution_time_ms": exec_time,
+        }

--- a/packages/brain/agent/runtime/native_runtime.py
+++ b/packages/brain/agent/runtime/native_runtime.py
@@ -1,0 +1,99 @@
+"""Native runtime backend for direct host execution."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+from typing import Any, Mapping
+
+from agent.runtime.base import RuntimeCapabilities, RuntimeErrorResult, RuntimeMode
+
+
+class NativeRuntime:
+    """Execute tool payloads directly on the host runtime."""
+
+    def __init__(self):
+        self._capabilities = RuntimeCapabilities(
+            mode=RuntimeMode.NATIVE,
+            supports_native_execution=True,
+            supports_computer_use=True,
+            supports_host_shell=True,
+            supports_host_python=True,
+            supports_code_languages=("python", "javascript", "shell"),
+        )
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        return self._capabilities
+
+    async def execute(self, *, tool_name: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        if tool_name in {"host_shell", "code_execute"} and payload.get("language") in (None, "shell"):
+            command = str(payload.get("command") or payload.get("code") or "")
+            return await self._run_shell(command)
+
+        if tool_name in {"host_python", "code_execute"} and payload.get("language") in (None, "python"):
+            code = str(payload.get("code", ""))
+            return await self._run_python(code)
+
+        if tool_name == "code_execute" and payload.get("language") == "javascript":
+            return await self._run_node(str(payload.get("code", "")))
+
+        if tool_name == "computer_use":
+            return {"success": True, "note": "computer_use executes in tool handler on native runtime."}
+
+        raise RuntimeErrorResult(f"Native runtime does not handle tool: {tool_name}")
+
+    async def _run_shell(self, command: str) -> dict[str, Any]:
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        return {
+            "success": proc.returncode == 0,
+            "output": stdout.decode(),
+            "error": stderr.decode(),
+            "exit_code": proc.returncode,
+        }
+
+    async def _run_python(self, code: str) -> dict[str, Any]:
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+                f.write(code)
+                tmp_path = f.name
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                tmp_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+            return {
+                "success": proc.returncode == 0,
+                "output": stdout.decode(),
+                "error": stderr.decode(),
+                "exit_code": proc.returncode,
+            }
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    async def _run_node(self, code: str) -> dict[str, Any]:
+        proc = await asyncio.create_subprocess_exec(
+            "node",
+            "-e",
+            code,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        return {
+            "success": proc.returncode == 0,
+            "output": stdout.decode(),
+            "error": stderr.decode(),
+            "exit_code": proc.returncode,
+        }

--- a/packages/brain/agent/runtime/policy.py
+++ b/packages/brain/agent/runtime/policy.py
@@ -1,0 +1,73 @@
+"""Runtime policy selection and tool routing."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from agent.runtime.base import ExecutionRuntime, RuntimeCapabilities, RuntimeMode
+from agent.runtime.docker_runtime import DockerRuntime
+from agent.runtime.native_runtime import NativeRuntime
+
+logger = logging.getLogger("brain.agent.runtime.policy")
+
+
+@dataclass
+class HybridRuntime:
+    """Hybrid runtime that can route requests to docker or native backends."""
+
+    docker: DockerRuntime
+    native: NativeRuntime
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        dc = self.docker.capabilities
+        nc = self.native.capabilities
+        return RuntimeCapabilities(
+            mode=RuntimeMode.HYBRID,
+            supports_docker_execution=dc.supports_docker_execution,
+            supports_native_execution=nc.supports_native_execution,
+            supports_computer_use=nc.supports_computer_use,
+            supports_host_shell=nc.supports_host_shell,
+            supports_host_python=nc.supports_host_python,
+            supports_code_languages=tuple(sorted(set(dc.supports_code_languages + nc.supports_code_languages))),
+        )
+
+    async def execute(self, *, tool_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if tool_name in {"host_shell", "host_python", "computer_use"}:
+            return await self.native.execute(tool_name=tool_name, payload=payload)
+
+        if tool_name == "code_execute":
+            language = payload.get("language")
+            if self.docker.capabilities.supports_docker_execution:
+                return await self.docker.execute(tool_name=tool_name, payload=payload)
+            if language in {"python", "javascript", "shell"}:
+                return await self.native.execute(tool_name=tool_name, payload=payload)
+
+        return await self.docker.execute(tool_name=tool_name, payload=payload)
+
+
+def _parse_mode(raw_mode: str) -> RuntimeMode:
+    normalized = (raw_mode or RuntimeMode.DOCKER.value).strip().lower()
+    if normalized == RuntimeMode.NATIVE.value:
+        return RuntimeMode.NATIVE
+    if normalized == RuntimeMode.HYBRID.value:
+        return RuntimeMode.HYBRID
+    return RuntimeMode.DOCKER
+
+
+def build_runtime_policy(*, hands_client: Any = None) -> ExecutionRuntime:
+    """Build active runtime policy based on KESTREL_RUNTIME_MODE."""
+
+    mode = _parse_mode(os.getenv("KESTREL_RUNTIME_MODE", RuntimeMode.DOCKER.value))
+    if mode == RuntimeMode.NATIVE:
+        runtime = NativeRuntime()
+    elif mode == RuntimeMode.HYBRID:
+        runtime = HybridRuntime(docker=DockerRuntime(hands_client=hands_client), native=NativeRuntime())
+    else:
+        runtime = DockerRuntime(hands_client=hands_client)
+
+    logger.info("Active runtime mode=%s capabilities=%s", mode.value, runtime.capabilities.as_dict())
+    return runtime

--- a/packages/brain/agent/tools/__init__.py
+++ b/packages/brain/agent/tools/__init__.py
@@ -10,6 +10,7 @@ import logging
 import time
 from typing import Callable, Dict, Optional
 
+from agent.runtime import set_active_runtime
 from agent.types import (
     RiskLevel,
     ToolCall,
@@ -205,7 +206,7 @@ class ToolRegistry:
             )
 
 
-def build_tool_registry(hands_client=None, vector_store=None, pool=None) -> ToolRegistry:
+def build_tool_registry(hands_client=None, vector_store=None, pool=None, runtime_policy=None) -> ToolRegistry:
     """
     Build the default tool registry with all built-in tools.
     Called during server startup.
@@ -215,8 +216,11 @@ def build_tool_registry(hands_client=None, vector_store=None, pool=None) -> Tool
             If provided, code execution routes through the Hands service.
             If None, code execution will fail safely with an error message.
         vector_store: Optional VectorStore for memory tools.
+        runtime_policy: Active runtime policy used by execution-oriented tools.
     """
     registry = ToolRegistry()
+
+    set_active_runtime(runtime_policy)
 
     # Import and register all built-in tools
     from agent.tools.code import register_code_tools
@@ -232,7 +236,7 @@ def build_tool_registry(hands_client=None, vector_store=None, pool=None) -> Tool
     from agent.tools.system_tools import register_system_tools
     from agent.tools.host_execution import register_host_execution_tools
 
-    register_code_tools(registry, hands_client=hands_client)
+    register_code_tools(registry)
     register_web_tools(registry)
     register_file_tools(registry)
     register_host_file_tools(registry, vector_store=vector_store)

--- a/packages/brain/agent/tools/code.py
+++ b/packages/brain/agent/tools/code.py
@@ -1,37 +1,23 @@
 """
 Code execution tool — runs Python/JS/Shell in a sandboxed environment.
 
-Routes execution through the Hands gRPC service for containerized sandboxing
-with resource limits, network controls, and audit logging.
-
-SECURITY: Local fallback execution has been removed. If the Hands service
-is not available, code execution fails safely. Python's exec() cannot be
-secured via globals restriction — object introspection allows trivial escape.
+Routes execution through the active runtime policy (docker/native/hybrid)
+and exposes runtime capability metadata in responses.
 """
 
-import json
 import logging
-from typing import Optional
 
+from agent.runtime import get_active_runtime
 from agent.types import RiskLevel, ToolDefinition
 
 logger = logging.getLogger("brain.agent.tools.code")
 
-# Hands gRPC client reference (set during registration)
-_hands_client = None
-
-
-def register_code_tools(registry, hands_client=None) -> None:
+def register_code_tools(registry) -> None:
     """Register code execution tools.
 
     Args:
         registry: The tool registry to register with.
-        hands_client: The Hands gRPC client for sandboxed execution.
-            If None, code execution will return an error directing
-            the user to start the Hands service.
     """
-    global _hands_client
-    _hands_client = hands_client
 
     registry.register(
         definition=ToolDefinition(
@@ -75,77 +61,33 @@ async def execute_code(
     timeout: int = 30,
 ) -> dict:
     """
-    Execute code in a sandboxed environment via the Hands gRPC service.
-
-    If the Hands service is not available, returns an error. Local fallback
-    execution has been removed for security — Python's exec() cannot be
-    safely sandboxed via globals restriction.
+    Execute code through the active runtime backend selected at startup.
     """
     timeout = min(timeout, 60)  # Cap at 60s
 
-    if not _hands_client:
+    active_runtime = get_active_runtime()
+    if not active_runtime:
         return {
             "success": False,
-            "error": (
-                "Code execution requires the Hands service for secure sandboxing. "
-                "The Hands service is not connected. Please ensure it is running "
-                "and properly configured."
-            ),
+            "error": "Runtime policy is not initialized.",
         }
 
-    return await _execute_via_hands(language, code, timeout)
-
-
-async def _execute_via_hands(language: str, code: str, timeout: int) -> dict:
-    """Execute code via the Hands gRPC service."""
-    try:
-        # Import proto types
-        import hands_pb2
-
-        # Map language to skill name
-        skill_map = {
-            "python": "python_executor",
-            "javascript": "node_executor",
-            "shell": "shell_executor",
-        }
-
-        skill_name = skill_map.get(language, "python_executor")
-
-        # Build protobuf request
-        request = hands_pb2.SkillExecutionRequest(
-            skill_name=skill_name,
-            function_name="run",
-            arguments=json.dumps({"code": code}),
-            limits=hands_pb2.ResourceLimits(
-                timeout_seconds=timeout,
-                memory_mb=512,
-                network_enabled=True,
-            ),
-        )
-
-        # Call Hands service (streaming response)
-        output_parts = []
-        error_parts = []
-        status = "RUNNING"
-        exec_time = 0
-
-        async for chunk in _hands_client.ExecuteSkill(request):
-            if chunk.output:
-                output_parts.append(chunk.output)
-            if chunk.error:
-                error_parts.append(chunk.error)
-            if chunk.execution_time_ms:
-                exec_time = chunk.execution_time_ms
-            # Map proto enum to string
-            status = hands_pb2.SkillExecutionResponse.Status.Name(chunk.status)
-
+    capabilities = active_runtime.capabilities
+    if language not in capabilities.supports_code_languages:
         return {
-            "success": status == "SUCCESS",
-            "output": "".join(output_parts),
-            "error": "".join(error_parts),
-            "execution_time_ms": exec_time,
+            "success": False,
+            "error": f"Language '{language}' is not supported in active runtime mode '{capabilities.mode.value}'.",
+            "capabilities": capabilities.as_dict(),
         }
 
+    try:
+        result = await active_runtime.execute(
+            tool_name="code_execute",
+            payload={"language": language, "code": code, "timeout": timeout},
+        )
+        if "capabilities" not in result:
+            result["capabilities"] = capabilities.as_dict()
+        return result
     except Exception as e:
-        logger.error(f"Hands execution failed: {e}")
-        return {"success": False, "error": str(e)}
+        logger.error(f"Runtime execution failed: {e}")
+        return {"success": False, "error": str(e), "capabilities": capabilities.as_dict()}

--- a/packages/brain/agent/tools/computer_use.py
+++ b/packages/brain/agent/tools/computer_use.py
@@ -41,6 +41,7 @@ from typing import Any, Optional
 
 import httpx
 
+from agent.runtime import get_active_runtime
 from agent.types import RiskLevel, ToolDefinition
 
 logger = logging.getLogger("brain.agent.tools.computer_use")
@@ -607,12 +608,27 @@ def register_computer_use_tools(registry) -> None:
         excluded_actions: Optional[list[str]] = None,
     ) -> dict:
         """Handle computer_use tool calls from the agent loop."""
-        return await run_computer_use(
+        active_runtime = get_active_runtime()
+        if not active_runtime:
+            return {"success": False, "error": "Runtime policy is not initialized."}
+
+        capabilities = active_runtime.capabilities
+        if not capabilities.supports_computer_use:
+            return {
+                "success": False,
+                "error": f"computer_use is disabled in runtime mode '{capabilities.mode.value}'.",
+                "capabilities": capabilities.as_dict(),
+            }
+
+        result = await run_computer_use(
             goal=goal,
             max_turns=max_turns,
             excluded_actions=excluded_actions,
             require_confirmation=True,
         )
+        if isinstance(result, dict):
+            result.setdefault("capabilities", capabilities.as_dict())
+        return result
 
     registry.register(definition=COMPUTER_USE_TOOL, handler=computer_use_handler)
     logger.info("Computer Use tool registered")

--- a/packages/brain/agent/tools/host_execution.py
+++ b/packages/brain/agent/tools/host_execution.py
@@ -5,11 +5,10 @@ on the host machine. Regulated by an allowlist and native macOS approval dialogs
 """
 
 import os
-import sys
 import asyncio
 import logging
-import tempfile
 from datetime import datetime
+from agent.runtime import get_active_runtime
 from agent.types import RiskLevel, ToolDefinition
 
 logger = logging.getLogger("brain.agent.tools.host_execution")
@@ -89,6 +88,18 @@ def _check_allowlist(command: str) -> bool:
 
 async def execute_host_shell(command: str) -> dict:
     """Execute a shell command directly on the host OS."""
+    active_runtime = get_active_runtime()
+    if not active_runtime:
+        return {"success": False, "error": "Runtime policy is not initialized.", "output": ""}
+
+    capabilities = active_runtime.capabilities
+    if not capabilities.supports_host_shell:
+        return {
+            "success": False,
+            "error": f"host_shell is disabled in runtime mode '{capabilities.mode.value}'.",
+            "output": "",
+            "capabilities": capabilities.as_dict(),
+        }
     
     # 1. Check Allowlist
     is_allowed = _check_allowlist(command)
@@ -107,18 +118,9 @@ async def execute_host_shell(command: str) -> dict:
     # 3. Execute and audit
     _audit_log(command, "shell", approved=True)
     try:
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
-        )
-        stdout, stderr = await proc.communicate()
-        return {
-            "success": proc.returncode == 0,
-            "output": stdout.decode(),
-            "error": stderr.decode(),
-            "exit_code": proc.returncode
-        }
+        result = await active_runtime.execute(tool_name="host_shell", payload={"command": command})
+        result["capabilities"] = capabilities.as_dict()
+        return result
     except Exception as e:
         _audit_log(command, "shell", approved=True, error=str(e))
         return {
@@ -129,6 +131,18 @@ async def execute_host_shell(command: str) -> dict:
 
 async def execute_host_python(code: str) -> dict:
     """Execute python code directly on the host OS."""
+    active_runtime = get_active_runtime()
+    if not active_runtime:
+        return {"success": False, "error": "Runtime policy is not initialized.", "output": ""}
+
+    capabilities = active_runtime.capabilities
+    if not capabilities.supports_host_python:
+        return {
+            "success": False,
+            "error": f"host_python is disabled in runtime mode '{capabilities.mode.value}'.",
+            "output": "",
+            "capabilities": capabilities.as_dict(),
+        }
     
     # We serialize the code to a temporary file and run `python3 cache_file.py`
     # Always prompt for native approval for host python unless we build a complex analysis
@@ -144,24 +158,10 @@ async def execute_host_python(code: str) -> dict:
         }
 
     _audit_log("Python Script", "python", approved=True)
-    tmp_path = None
     try:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(code)
-            tmp_path = f.name
-
-        proc = await asyncio.create_subprocess_exec(
-            sys.executable, tmp_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
-        )
-        stdout, stderr = await proc.communicate()
-        return {
-            "success": proc.returncode == 0,
-            "output": stdout.decode(),
-            "error": stderr.decode(),
-            "exit_code": proc.returncode
-        }
+        result = await active_runtime.execute(tool_name="host_python", payload={"code": code})
+        result["capabilities"] = capabilities.as_dict()
+        return result
     except Exception as e:
         _audit_log("Python Script", "python", approved=True, error=str(e))
         return {
@@ -169,12 +169,6 @@ async def execute_host_python(code: str) -> dict:
             "error": str(e),
             "output": ""
         }
-    finally:
-        if tmp_path and os.path.exists(tmp_path):
-            try:
-                os.remove(tmp_path)
-            except Exception:
-                pass
 
 def register_host_execution_tools(registry) -> None:
     registry.register(

--- a/packages/brain/core/cron.py
+++ b/packages/brain/core/cron.py
@@ -39,6 +39,7 @@ async def _run_automation_task(task: AgentTask, source: str = "automation", mode
                 hands_client=runtime.hands_client,
                 vector_store=runtime.vector_store,
                 pool=pool,
+                runtime_policy=runtime.execution_runtime,
             ),
             guardrails=Guardrails(),
             persistence=runtime.agent_persistence,

--- a/packages/brain/core/runtime.py
+++ b/packages/brain/core/runtime.py
@@ -31,6 +31,7 @@ class Runtime:
     running_tasks: Dict[str, Any] = field(default_factory=dict)
 
     hands_client: Any = None
+    execution_runtime: Any = None
     cron_scheduler: Any = None
     webhook_handler: Any = None
     memory_graph: Any = None

--- a/packages/brain/server.py
+++ b/packages/brain/server.py
@@ -132,6 +132,7 @@ async def serve():
         logger.warning(f"Could not connect to Hands service: {e}")
 
     # Initialize agent runtime
+    from agent.runtime import build_runtime_policy
     from agent.tools import build_tool_registry
     from agent.guardrails import Guardrails
     from agent.loop import AgentLoop
@@ -156,7 +157,12 @@ async def serve():
     from agent.proactive import ProactiveEngine
     from agent.ui_artifacts import UIArtifactManager
     pool = await get_pool()
-    runtime.tool_registry = build_tool_registry(hands_client=runtime.hands_client, pool=pool)
+    runtime.execution_runtime = build_runtime_policy(hands_client=runtime.hands_client)
+    runtime.tool_registry = build_tool_registry(
+        hands_client=runtime.hands_client,
+        pool=pool,
+        runtime_policy=runtime.execution_runtime,
+    )
     guardrails = Guardrails()
     runtime.agent_persistence = PostgresTaskPersistence(pool=pool)
 

--- a/packages/brain/services/agent_service.py
+++ b/packages/brain/services/agent_service.py
@@ -96,7 +96,7 @@ class AgentServicerMixin(BaseServicerMixin):
         task_model = ws_config.get("model", "") if ws_config else ""
         task_api_key = ws_config.get("api_key", "") if ws_config else ""
 
-        task_tool_registry = build_tool_registry(hands_client=runtime.hands_client, pool=pool)
+        task_tool_registry = build_tool_registry(hands_client=runtime.hands_client, pool=pool, runtime_policy=runtime.execution_runtime)
         evidence_chain = EvidenceChain(task_id=task.id, pool=pool)
 
         task_working_memory = WorkingMemory(
@@ -408,7 +408,7 @@ class AgentServicerMixin(BaseServicerMixin):
 
         task_model = ws_config.get("model", "") if ws_config else ""
         task_api_key = ws_config.get("api_key", "") if ws_config else ""
-        task_tool_registry = build_tool_registry(hands_client=runtime.hands_client, pool=pool)
+        task_tool_registry = build_tool_registry(hands_client=runtime.hands_client, pool=pool, runtime_policy=runtime.execution_runtime)
         evidence_chain = EvidenceChain(task_id=task.id, pool=pool)
 
         task_working_memory = WorkingMemory(redis_client=None, vector_store=runtime.vector_store)

--- a/packages/brain/services/chat_service.py
+++ b/packages/brain/services/chat_service.py
@@ -289,7 +289,7 @@ class ChatServicerMixin(BaseServicerMixin):
                 chat_task.plan = None
 
             # Build tool registry and agent loop
-            tool_registry = build_tool_registry(hands_client=runtime.hands_client, vector_store=runtime.vector_store, pool=pool)
+            tool_registry = build_tool_registry(hands_client=runtime.hands_client, vector_store=runtime.vector_store, pool=pool, runtime_policy=runtime.execution_runtime)
 
             # Set workspace context for Moltbook activity logging
             import agent.tools.moltbook as _moltbook_mod


### PR DESCRIPTION
### Motivation
- Remove hardcoded Docker/Hands assumptions and centralize execution policy so tools can adapt to docker, native, or hybrid environments.
- Expose runtime capability metadata so tool handlers can make policy-aware decisions before executing high-risk actions.
- Provide an environment-driven selection (`KESTREL_RUNTIME_MODE`) at startup to control permitted execution surfaces.

### Description
- Add a runtime abstraction under `packages/brain/agent/runtime/` including `base.py` (contract and capabilities), `docker_runtime.py` (Hands-based execution), `native_runtime.py` (host execution), and `policy.py` (env-driven selection and hybrid routing). 
- Wire an active runtime into the tool registry via `agent.runtime.set_active_runtime` and initialize it at server startup using `KESTREL_RUNTIME_MODE` so the registry and all tools can query the active runtime. 
- Refactor `packages/brain/agent/tools/code.py` to resolve `code_execute` calls through the active runtime instead of relying on a global Hands client and to return capability metadata in responses. 
- Update `host_shell`, `host_python`, and `computer_use` handlers to check runtime capabilities before execution and to route execution through the runtime backend when permitted. 

### Testing
- Compiled the modified modules with `python -m compileall` for the runtime and affected tools and startup modules, and compilation succeeded for the updated files. 
- Verified registry wiring by updating startup and task/bootstrap call sites to pass the built runtime policy into `build_tool_registry`; no import/compile errors observed. 

*Context improved by Giga AI: used AGENTS.md Development Guidelines and the main-overview sections to guide scoped changes and ensure the runtime/tooling context was respected.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbc30e90c832a92c6fc96aff0ddca)