### PR TITLE
fix(runtime): fallback to native when Docker code execution runtime is unavailable

### DIFF
--- a/packages/brain/agent/runtime/policy.py
+++ b/packages/brain/agent/runtime/policy.py
@@ -14,6 +14,33 @@ from agent.runtime.native_runtime import NativeRuntime
 logger = logging.getLogger("brain.agent.runtime.policy")
 
 
+def _should_fallback_to_native(*, language: Any, docker_result: dict[str, Any]) -> bool:
+    """Return True when hybrid mode should retry code execution on native runtime.
+
+    This is intentionally narrow: only fallback for supported languages when the
+    Docker execution path failed due to sandbox/container availability issues.
+    """
+    if language not in {"python", "javascript", "shell"}:
+        return False
+
+    if docker_result.get("success") is True:
+        return False
+
+    error_text = str(docker_result.get("error", "")).lower()
+    if not error_text:
+        return False
+
+    fallback_signals = (
+        "pull access denied",
+        "image",
+        "not found",
+        "hands service is not connected",
+        "no such container",
+        "manifest unknown",
+    )
+    return any(signal in error_text for signal in fallback_signals)
+
+
 @dataclass
 class HybridRuntime:
     """Hybrid runtime that can route requests to docker or native backends."""
@@ -42,7 +69,21 @@ class HybridRuntime:
         if tool_name == "code_execute":
             language = payload.get("language")
             if self.docker.capabilities.supports_docker_execution:
-                return await self.docker.execute(tool_name=tool_name, payload=payload)
+                docker_result = await self.docker.execute(tool_name=tool_name, payload=payload)
+                if _should_fallback_to_native(language=language, docker_result=docker_result):
+                    logger.warning(
+                        "Docker code execution failed with sandbox/runtime error; "
+                        "falling back to native execution for language=%s",
+                        language,
+                    )
+                    native_result = await self.native.execute(tool_name=tool_name, payload=payload)
+                    native_result.setdefault("warnings", [])
+                    native_result["warnings"].append(
+                        "Docker runtime unavailable; executed via native runtime fallback."
+                    )
+                    native_result.setdefault("docker_error", docker_result.get("error", ""))
+                    return native_result
+                return docker_result
             if language in {"python", "javascript", "shell"}:
                 return await self.native.execute(tool_name=tool_name, payload=payload)
 

--- a/packages/brain/tests/test_runtime_policy_fallback.py
+++ b/packages/brain/tests/test_runtime_policy_fallback.py
@@ -1,0 +1,72 @@
+import pytest
+
+from agent.runtime.policy import HybridRuntime, _should_fallback_to_native
+
+
+class _FakeDocker:
+    def __init__(self, result, supports=True):
+        self._result = result
+        self.capabilities = type("Caps", (), {"supports_docker_execution": supports})()
+
+    async def execute(self, *, tool_name, payload):
+        return self._result
+
+
+class _FakeNative:
+    def __init__(self, result):
+        self._result = result
+
+    async def execute(self, *, tool_name, payload):
+        return self._result
+
+
+@pytest.mark.parametrize(
+    "error_text,expected",
+    [
+        ("pull access denied for kestrel/sandbox", True),
+        ("image not found", True),
+        ("Hands service is not connected", True),
+        ("syntax error in python code", False),
+        ("", False),
+    ],
+)
+def test_should_fallback_to_native_detects_runtime_errors(error_text, expected):
+    result = _should_fallback_to_native(
+        language="python",
+        docker_result={"success": False, "error": error_text},
+    )
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_hybrid_runtime_falls_back_to_native_when_docker_image_missing():
+    hybrid = HybridRuntime(
+        docker=_FakeDocker({"success": False, "error": "pull access denied for kestrel/sandbox"}),
+        native=_FakeNative({"success": True, "output": "ok from native"}),
+    )
+
+    result = await hybrid.execute(
+        tool_name="code_execute",
+        payload={"language": "python", "code": "print('hello')"},
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "ok from native"
+    assert "warnings" in result
+    assert "native runtime fallback" in result["warnings"][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_hybrid_runtime_keeps_docker_result_for_non_runtime_error():
+    docker_result = {"success": False, "error": "SyntaxError: invalid syntax"}
+    hybrid = HybridRuntime(
+        docker=_FakeDocker(docker_result),
+        native=_FakeNative({"success": True, "output": "should not be used"}),
+    )
+
+    result = await hybrid.execute(
+        tool_name="code_execute",
+        payload={"language": "python", "code": "bad code"},
+    )
+
+    assert result == docker_result


### PR DESCRIPTION
### Motivation
- Hybrid runtime always preferred the Docker-backed sandbox for `code_execute`, which led to task failures when Docker/Hands sandbox images or services were unavailable (e.g. image pull denied / not found).  
- Those runtime failures manifested as repeated 404/pull errors and long-running approval/failure loops for simple requests.  
- Add a narrow, safe fallback so short-running code tasks can still complete when the Docker sandbox is unavailable.

### Description
- Added `_should_fallback_to_native` helper to detect Docker sandbox/runtime availability errors for supported languages (`python`, `javascript`, `shell`).
- Updated `HybridRuntime.execute` to call Docker first when available, and if Docker returns a sandbox/runtime error signal, retry once using the native runtime and attach a `warnings` entry and `docker_error` field to the native result.  
- Preserved original behavior for non-runtime (semantic) Docker errors by returning the Docker result unchanged.  
- Added `packages/brain/tests/test_runtime_policy_fallback.py` to cover detection of fallback signals, successful native fallback, and non-fallback behavior for semantic errors.

### Testing
- Ran `pytest -q packages/brain/tests/test_runtime_policy_fallback.py` and all tests in that file passed (`7 passed`).
- Ran `pytest -q packages/brain/tests/test_policy_engine.py packages/brain/tests/test_task_profiles.py` to ensure no regressions and both suites passed (`8 passed`).

*Context improved by Giga AI: Used AGENTS.md main-overview information about the agent runtime, tool routing, and the importance of resilient code execution routing to design a narrow fallback that preserves safety and audibility.*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15c158840832a9fe2c009eaad4214)