### PR TITLE
fix: stop leaking raw step_complete JSON to Telegram

### DIFF
--- a/packages/brain/agent/runtime/engine.py
+++ b/packages/brain/agent/runtime/engine.py
@@ -225,13 +225,7 @@ class LangGraphEngine:
             if mapped_type is None:
                 return
 
-            import json
             content = payload.get("content") or payload.get("result") or ""
-            if not content:
-                try:
-                    content = json.dumps(payload)
-                except Exception:
-                    content = str(payload)
 
             logger.info(
                 f"_bridging_callback: event_type={event_type}, "


### PR DESCRIPTION
When _bridging_callback received an event with empty content (e.g.
step_complete), it fell back to json.dumps(payload), serializing the
entire internal event object and setting it as the message content.
tool_parser.py then forwarded this as a content_delta, causing raw
JSON blobs like {"type": "step_complete", ...} to appear in Telegram.

Remove the json.dumps fallback — empty content is intentional for
bookkeeping events and tool_parser.py already guards against it.

https://claude.ai/code/session_017yHRxyK3ffzuv77ZWSjE1L