### PR TITLE
fix: harden tool approvals and run cancellation

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -14,7 +14,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - OpenAI Responses provider adapter using the portable JSON tool envelope.
 - OpenAI-compatible chat completions provider for local/model-server endpoints.
 - Codex CLI provider that can use local `codex exec` as the normal response engine.
-- Built-in tool registry with approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
+- Built-in tool registry with structured exception boundaries and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `3`.
@@ -48,7 +48,8 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 
 ## Current Contract
 
-- High-risk tools must remain blocked unless the matching allow flag is set or a human approval handler approves the exact tool call.
+- High-risk tools require both capability enablement (matching allow flag, where applicable) and explicit approval for the exact tool-call ID and arguments before execution.
+- Cancelled runs must not transition to completed, blocked, or failed after cancellation.
 - Ordinary conversation and observations must not write policy memory directly.
 - The Memvid backend must use `.mv2` files and preserve one file per memory layer.
 - `complete.mv2` is a run artifact under `.nest/runs/{run_id}/`, not a permanent memory layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ memvid = ["memvid-sdk>=2.0"]
 openai = ["openai>=1.0"]
 server = ["fastapi>=0.110", "uvicorn>=0.29"]
 mcp = ["mcp>=1.0"]
-dev = ["pytest>=8.0", "ruff>=0.6", "mypy>=1.10"]
+dev = ["pytest>=8.0", "ruff>=0.6", "mypy>=1.10", "fastapi>=0.110", "uvicorn>=0.29"]
 
 [project.scripts]
 nested-memvid = "nested_memvid_agent.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ memvid = ["memvid-sdk>=2.0"]
 openai = ["openai>=1.0"]
 server = ["fastapi>=0.110", "uvicorn>=0.29"]
 mcp = ["mcp>=1.0"]
-dev = ["pytest>=8.0", "ruff>=0.6", "mypy>=1.10", "fastapi>=0.110", "uvicorn>=0.29"]
+dev = ["pytest>=8.0", "ruff>=0.6", "mypy>=1.10", "fastapi>=0.110", "uvicorn>=0.29", "httpx>=0.27"]
 
 [project.scripts]
 nested-memvid = "nested_memvid_agent.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,7 @@ python_version = "3.11"
 strict = true
 warn_unused_ignores = true
 exclude = ["build", "dist"]
+
+[[tool.mypy.overrides]]
+module = ["uvicorn"]
+ignore_missing_imports = true

--- a/src/nested_memvid_agent/run_manager.py
+++ b/src/nested_memvid_agent/run_manager.py
@@ -236,6 +236,8 @@ class RunManager:
                 approval_handler=self._approval_handler,
                 stream_handler=self._stream_handler(run_id),
             )
+            if self._is_cancelled(run_id):
+                return
             self._publish_turn_observability(run_id, result)
             for execution in result.tool_executions:
                 self.events.publish(run_id, "tool.executed", _execution_payload(execution))
@@ -257,6 +259,8 @@ class RunManager:
                 self._complete_capsule(run_id, config, agent, result)
             self.events.publish(run_id, "run.blocked" if status == "blocked" else "run.completed", _turn_payload(result))
         except Exception as exc:  # noqa: BLE001
+            if self._is_cancelled(run_id):
+                return
             self.state.update_run(run_id, status="failed", error=f"{type(exc).__name__}: {exc}", stop_reason="error")
             self.events.publish(run_id, "run.failed", {"error": f"{type(exc).__name__}: {exc}"})
         finally:
@@ -264,6 +268,8 @@ class RunManager:
 
     def _resume_after_approval(self, approval: dict[str, Any], arguments: dict[str, Any]) -> None:
         run_id = str(approval["run_id"])
+        if self._is_cancelled(run_id):
+            return
         run = self.state.get_run(run_id)
         config = replace(self.config, workspace=Path(run.workspace), model=run.model)
         self.state.update_run(run_id, status="running", stop_reason="resuming_after_approval")
@@ -279,6 +285,8 @@ class RunManager:
     ) -> None:
         agent = self._build_agent(config)
         try:
+            if self._is_cancelled(run_id):
+                return
             call = ToolCall(name=str(approval["tool_name"]), arguments=arguments, id=str(approval["tool_call_id"]))
             execution = agent.tools.execute(
                 call,
@@ -290,6 +298,7 @@ class RunManager:
                     session_id=session_id,
                     run_id=run_id,
                     approved_tool_call_ids=frozenset({call.id}),
+                    approved_tool_call_arguments={call.id: arguments},
                 ),
             )
             self.state.decide_approval(
@@ -312,6 +321,8 @@ class RunManager:
                 approval_handler=self._approval_handler,
                 stream_handler=self._stream_handler(run_id),
             )
+            if self._is_cancelled(run_id):
+                return
             self._publish_turn_observability(run_id, result)
             status = "blocked" if result.stop_reason == "approval_required" else "completed"
             self.state.update_run(
@@ -326,6 +337,8 @@ class RunManager:
                 self._complete_capsule(run_id, config, agent, result)
             self.events.publish(run_id, "run.blocked" if status == "blocked" else "run.completed", _turn_payload(result))
         except Exception as exc:  # noqa: BLE001
+            if self._is_cancelled(run_id):
+                return
             self.state.update_run(run_id, status="failed", error=f"{type(exc).__name__}: {exc}", stop_reason="error")
             self.events.publish(run_id, "run.failed", {"error": f"{type(exc).__name__}: {exc}"})
         finally:

--- a/src/nested_memvid_agent/tools/base.py
+++ b/src/nested_memvid_agent/tools/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -24,6 +24,7 @@ class ToolContext:
     run_id: str | None = None
     approval_handler: ApprovalHandler | None = None
     approved_tool_call_ids: frozenset[str] = frozenset()
+    approved_tool_call_arguments: Mapping[str, dict[str, Any]] | None = None
 
 
 class AgentTool(ABC):

--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -38,7 +38,15 @@ class MemorySearchTool(AgentTool):
         if not query:
             return self._result(call, success=False, content="Missing query", error="missing_query")
         layer_values = arguments.get("layers")
-        layers = tuple(MemoryLayer(value) for value in layer_values) if isinstance(layer_values, list) else tuple(MemoryLayer)
+        try:
+            layers = tuple(MemoryLayer(value) for value in layer_values) if isinstance(layer_values, list) else tuple(MemoryLayer)
+        except ValueError as exc:
+            return self._result(
+                call,
+                success=False,
+                content=f"Unknown memory layer: {exc}",
+                error="invalid_tool_arguments",
+            )
         k = int(arguments.get("k", 8))
         hits = context.memory.retrieve(RetrievalQuery(query=query, layers=layers, k_per_layer=k))
         rows = []

--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from ..runtime_models import ToolCall, ToolExecution, ToolSpec
 from .base import AgentTool, ToolContext
 
@@ -18,38 +20,64 @@ class ToolRegistry:
 
     def execute(self, call: ToolCall, context: ToolContext) -> ToolExecution:
         if not isinstance(call.arguments, dict):
-            return ToolExecution(
-                call=call,
-                success=False,
+            return _failure(
+                call,
                 content=f"Tool {call.name} arguments must be a JSON object.",
                 error="invalid_tool_arguments",
             )
         tool = self._tools.get(call.name)
         if tool is None:
-            return ToolExecution(
-                call=call,
-                success=False,
-                content=f"Unknown tool: {call.name}",
-                error="unknown_tool",
-            )
-        if tool.spec.requires_approval and context.config.require_approval_for_high_risk_tools:
-            if call.id in context.approved_tool_call_ids:
-                return tool.run(call.arguments, context)
-            enablement_attr = _ENABLEMENT_BY_TOOL.get(tool.spec.name)
-            if enablement_attr and bool(getattr(context.config, enablement_attr)):
-                return tool.run(call.arguments, context)
-            if context.approval_handler is not None:
-                return context.approval_handler(call, tool.spec, context)
-            return ToolExecution(
-                call=call,
-                success=False,
-                content=f"Tool {call.name} requires approval or config enablement.",
-                error="approval_required",
-            )
+            return _failure(call, content=f"Unknown tool: {call.name}", error="unknown_tool")
+
         arguments = dict(call.arguments)
         if getattr(tool, "needs_call_id", False):
             arguments.setdefault("_tool_call_id", call.id)
+
+        if tool.spec.requires_approval and context.config.require_approval_for_high_risk_tools:
+            enabled, disabled_reason = _capability_enabled(tool, context)
+            if not enabled:
+                return _failure(call, content=disabled_reason, error="tool_disabled")
+            if _is_exact_call_approved(call, arguments, context):
+                return _run_tool(tool, call, arguments, context)
+            if context.approval_handler is not None:
+                return context.approval_handler(call, tool.spec, context)
+            return _failure(
+                call,
+                content=f"Tool {call.name} requires explicit approval for this exact call.",
+                error="approval_required",
+            )
+
+        return _run_tool(tool, call, arguments, context)
+
+
+def _capability_enabled(tool: AgentTool, context: ToolContext) -> tuple[bool, str]:
+    enablement_attr = _ENABLEMENT_BY_TOOL.get(tool.spec.name)
+    if not enablement_attr:
+        return True, ""
+    if bool(getattr(context.config, enablement_attr)):
+        return True, ""
+    return False, f"Tool {tool.spec.name} is disabled. Enable {enablement_attr} before requesting approval."
+
+
+def _is_exact_call_approved(call: ToolCall, arguments: dict[str, Any], context: ToolContext) -> bool:
+    if call.id not in context.approved_tool_call_ids:
+        return False
+    approved_arguments = context.approved_tool_call_arguments
+    if approved_arguments is None:
+        # Backwards-compatible path for internal callers that only track approved IDs.
+        return True
+    return approved_arguments.get(call.id) == arguments
+
+
+def _run_tool(tool: AgentTool, call: ToolCall, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+    try:
         return tool.run(arguments, context)
+    except Exception as exc:  # noqa: BLE001 - registry boundary must never crash agent turns
+        return _failure(call, content=f"{type(exc).__name__}: {exc}", error="tool_execution_failed")
+
+
+def _failure(call: ToolCall, *, content: str, error: str) -> ToolExecution:
+    return ToolExecution(call=call, success=False, content=content, error=error)
 
 
 _ENABLEMENT_BY_TOOL = {

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -102,7 +102,7 @@ def test_agent_stops_on_direct_approval_required(tmp_path: Path) -> None:
             memory=memory,
             llm=llm,
             tools=build_default_tools(),
-            config=AgentConfig(memory_dir=tmp_path / "memory", log_dir=tmp_path / "logs"),
+            config=AgentConfig(memory_dir=tmp_path / "memory", log_dir=tmp_path / "logs", allow_shell=True),
             event_log=event_log,
         )
     )

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -18,6 +18,7 @@ from nested_memvid_agent.run_manager import RunManager
 from nested_memvid_agent.server import create_app
 from nested_memvid_agent.skill_manager import SkillManager
 from nested_memvid_agent.state_store import AgentStateStore
+from nested_memvid_agent.runtime_models import AgentTurnResult
 from nested_memvid_agent.tools.builtin import build_default_tools
 
 
@@ -380,6 +381,44 @@ def test_skill_discovery_exposes_nested_learning_skill(tmp_path: Path) -> None:
     assert disabled["enabled"] is False
 
 
+def test_cancelled_run_cannot_be_overwritten_completed_after_agent_returns(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    manager.state.create_run(
+        run_id="run_cancel_race",
+        message="cancel me",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+
+    class CancellingAgent:
+        memory = None
+        config = manager.config
+
+        def chat(self, *args: object, **kwargs: object) -> AgentTurnResult:
+            manager.cancel_run("run_cancel_race")
+            return AgentTurnResult(
+                session_id="session",
+                user_message="cancel me",
+                assistant_message="done after cancel",
+                tool_executions=(),
+                context_chars=0,
+                memory_writes=(),
+                stop_reason="complete",
+            )
+
+        def close(self) -> None:
+            return None
+
+    manager._build_agent = lambda config: CancellingAgent()  # type: ignore[method-assign]
+
+    manager._run_agent_turn("run_cancel_race", manager.config, "cancel me", "session")
+
+    final = manager.get_run("run_cancel_race")
+    assert final["status"] == "cancelled"
+    assert final["stop_reason"] == "cancelled"
+
+
 def test_run_manager_completes_background_mock_run(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
     run = manager.create_run(message="hello", session_id="session")
@@ -440,6 +479,9 @@ def test_run_manager_publishes_stream_tokens(tmp_path: Path) -> None:
 
 def test_run_manager_pauses_and_resumes_approved_tool(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
+    manager.config = AgentConfig(
+        **{**manager.config.__dict__, "allow_shell": True}
+    )
     manager.state.create_run(
         run_id="run_manual",
         message="manual",
@@ -465,6 +507,9 @@ def test_run_manager_pauses_and_resumes_approved_tool(tmp_path: Path) -> None:
 
 def test_run_manager_marks_denied_approval_failed(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
+    manager.config = AgentConfig(
+        **{**manager.config.__dict__, "allow_shell": True}
+    )
     manager.state.create_run(
         run_id="run_manual",
         message="manual",

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -15,10 +15,10 @@ from nested_memvid_agent.mcp_manager import MCPManager
 from nested_memvid_agent.models import MemoryKind, MemoryLayer, MemoryRecord
 from nested_memvid_agent.orchestrator import build_memory_system
 from nested_memvid_agent.run_manager import RunManager
+from nested_memvid_agent.runtime_models import AgentTurnResult
 from nested_memvid_agent.server import create_app
 from nested_memvid_agent.skill_manager import SkillManager
 from nested_memvid_agent.state_store import AgentStateStore
-from nested_memvid_agent.runtime_models import AgentTurnResult
 from nested_memvid_agent.tools.builtin import build_default_tools
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,8 +9,7 @@ from pytest import MonkeyPatch
 from nested_memvid_agent.config import AgentConfig
 from nested_memvid_agent.models import MemoryKind, MemoryLayer, MemoryRecord, RetrievalQuery
 from nested_memvid_agent.orchestrator import build_memory_system
-from nested_memvid_agent.runtime_models import ToolCall
-from nested_memvid_agent.runtime_models import ToolExecution, ToolSpec
+from nested_memvid_agent.runtime_models import ToolCall, ToolExecution, ToolSpec
 from nested_memvid_agent.tools.base import AgentTool, ToolContext
 from nested_memvid_agent.tools.builtin import build_default_tools
 from nested_memvid_agent.tools.registry import ToolRegistry

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,8 +10,10 @@ from nested_memvid_agent.config import AgentConfig
 from nested_memvid_agent.models import MemoryKind, MemoryLayer, MemoryRecord, RetrievalQuery
 from nested_memvid_agent.orchestrator import build_memory_system
 from nested_memvid_agent.runtime_models import ToolCall
-from nested_memvid_agent.tools.base import ToolContext
+from nested_memvid_agent.runtime_models import ToolExecution, ToolSpec
+from nested_memvid_agent.tools.base import AgentTool, ToolContext
 from nested_memvid_agent.tools.builtin import build_default_tools
+from nested_memvid_agent.tools.registry import ToolRegistry
 
 
 def test_memory_search_tool_returns_hits(tmp_path: Path) -> None:
@@ -34,6 +36,20 @@ def test_memory_search_tool_returns_hits(tmp_path: Path) -> None:
     assert "Needle fact" in result.content
 
 
+def test_memory_search_invalid_layer_returns_structured_failure(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+
+    result = registry.execute(
+        ToolCall(name="memory.search", arguments={"query": "needle", "layers": ["bogus"]}),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+
+    assert not result.success
+    assert result.error == "invalid_tool_arguments"
+    assert "Unknown memory layer" in result.content
+
+
 def test_file_read_rejects_path_escape(tmp_path: Path) -> None:
     memory = build_memory_system("memory", tmp_path / "memory")
     registry = build_default_tools()
@@ -53,7 +69,7 @@ def test_high_risk_tool_requires_enablement(tmp_path: Path) -> None:
         ToolContext(memory=memory, config=AgentConfig(allow_shell=False), workspace=tmp_path),
     )
     assert not result.success
-    assert result.error == "approval_required"
+    assert result.error == "tool_disabled"
 
 
 def test_malformed_tool_arguments_fail_cleanly(tmp_path: Path) -> None:
@@ -69,15 +85,68 @@ def test_malformed_tool_arguments_fail_cleanly(tmp_path: Path) -> None:
     assert result.error == "invalid_tool_arguments"
 
 
-def test_shell_tool_runs_when_enabled(tmp_path: Path) -> None:
+def test_high_risk_tool_with_allow_flag_still_requests_approval(tmp_path: Path) -> None:
     memory = build_memory_system("memory", tmp_path / "memory")
     registry = build_default_tools()
     result = registry.execute(
-        ToolCall(name="shell.run", arguments={"command": ["echo", "hi"]}),
+        ToolCall(name="shell.run", arguments={"command": ["echo", "hi"]}, id="shell1"),
         ToolContext(memory=memory, config=AgentConfig(allow_shell=True), workspace=tmp_path),
     )
-    assert result.success
-    assert "hi" in result.content
+    assert not result.success
+    assert result.error == "approval_required"
+
+
+def test_approved_exact_tool_call_runs_once_and_changed_args_do_not_run(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(name="shell.run", arguments={"command": ["echo", "hi"]}, id="shell_exact")
+
+    approved = registry.execute(
+        call,
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_shell=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"shell_exact"}),
+            approved_tool_call_arguments={"shell_exact": {"command": ["echo", "hi"]}},
+        ),
+    )
+    assert approved.success
+    assert "hi" in approved.content
+
+    changed = registry.execute(
+        ToolCall(name="shell.run", arguments={"command": ["echo", "bye"]}, id="shell_exact"),
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_shell=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"shell_exact"}),
+            approved_tool_call_arguments={"shell_exact": {"command": ["echo", "hi"]}},
+        ),
+    )
+    assert not changed.success
+    assert changed.error == "approval_required"
+
+
+def test_tool_exception_returns_structured_failure(tmp_path: Path) -> None:
+    class ExplodingTool(AgentTool):
+        spec = ToolSpec(name="test.explode", description="Explode", parameters={"type": "object"})
+
+        def run(self, arguments: dict[str, object], context: ToolContext) -> ToolExecution:
+            raise RuntimeError("boom")
+
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = ToolRegistry()
+    registry.register(ExplodingTool())
+
+    result = registry.execute(
+        ToolCall(name="test.explode", arguments={}),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+
+    assert not result.success
+    assert result.error == "tool_execution_failed"
+    assert "RuntimeError: boom" in result.content
 
 
 def test_default_registry_includes_spec_tools() -> None:
@@ -118,7 +187,7 @@ def test_codex_exec_requires_approval_by_default(tmp_path: Path) -> None:
         ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
     )
     assert not result.success
-    assert result.error == "approval_required"
+    assert result.error == "tool_disabled"
 
 
 def test_codex_exec_runs_when_enabled(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -142,8 +211,22 @@ def test_codex_exec_runs_when_enabled(tmp_path: Path, monkeypatch: MonkeyPatch) 
                 "sandbox": "workspace-write",
                 "timeout": 45,
             },
+            id="codex1",
         ),
-        ToolContext(memory=memory, config=AgentConfig(allow_codex_cli=True), workspace=tmp_path),
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_codex_cli=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"codex1"}),
+            approved_tool_call_arguments={
+                "codex1": {
+                    "prompt": "summarize this repo",
+                    "model": "gpt-test",
+                    "sandbox": "workspace-write",
+                    "timeout": 45,
+                }
+            },
+        ),
     )
 
     assert result.success
@@ -177,7 +260,7 @@ def test_patch_apply_requires_file_write_enablement(tmp_path: Path) -> None:
         ToolContext(memory=memory, config=AgentConfig(allow_file_write=False), workspace=tmp_path),
     )
     assert not result.success
-    assert result.error == "approval_required"
+    assert result.error == "tool_disabled"
 
 
 def test_file_write_still_blocks_path_escape_when_enabled(tmp_path: Path) -> None:
@@ -185,8 +268,14 @@ def test_file_write_still_blocks_path_escape_when_enabled(tmp_path: Path) -> Non
     registry = build_default_tools()
 
     result = registry.execute(
-        ToolCall(name="file.write", arguments={"path": "../outside.txt", "content": "no"}),
-        ToolContext(memory=memory, config=AgentConfig(allow_file_write=True), workspace=tmp_path),
+        ToolCall(name="file.write", arguments={"path": "../outside.txt", "content": "no"}, id="write1"),
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_file_write=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"write1"}),
+            approved_tool_call_arguments={"write1": {"path": "../outside.txt", "content": "no"}},
+        ),
     )
 
     assert not result.success
@@ -202,7 +291,7 @@ def test_lint_run_uses_shell_enablement_and_allowlist(tmp_path: Path, monkeypatc
         ToolCall(name="lint.run", arguments={"command": ["ruff", "check", "."]}),
         ToolContext(memory=memory, config=AgentConfig(allow_shell=False), workspace=tmp_path),
     )
-    assert blocked.error == "approval_required"
+    assert blocked.error == "tool_disabled"
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         assert command == ["ruff", "check", "."]
@@ -211,8 +300,14 @@ def test_lint_run_uses_shell_enablement_and_allowlist(tmp_path: Path, monkeypatc
 
     monkeypatch.setattr("nested_memvid_agent.tools.builtin.subprocess.run", fake_run)
     allowed = registry.execute(
-        ToolCall(name="lint.run", arguments={"command": ["ruff", "check", "."]}),
-        ToolContext(memory=memory, config=AgentConfig(allow_shell=True), workspace=tmp_path),
+        ToolCall(name="lint.run", arguments={"command": ["ruff", "check", "."]}, id="lint1"),
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_shell=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"lint1"}),
+            approved_tool_call_arguments={"lint1": {"command": ["ruff", "check", "."]}},
+        ),
     )
 
     assert allowed.success


### PR DESCRIPTION
## Summary
- Require high-risk tools to have capability enablement plus explicit exact-call approval before execution.
- Add structured ToolRegistry exception boundaries and structured invalid memory.search layer failures.
- Prevent cancelled runs from being overwritten by completed/blocked/failed states after agent return or approval resume.
- Update implementation status contract and regression tests.

## Test Plan
- python -m compileall -q src tests
- pytest -q
- .venv/bin/nest-agent chat --backend memory --provider mock --message "hello"

## Notes
- Bare nest-agent was not on PATH in this shell, so validation used the repo virtualenv binary.
