### PR TITLE
fix: guard run transitions and bound tool execution

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -14,7 +14,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - OpenAI Responses provider adapter using the portable JSON tool envelope.
 - OpenAI-compatible chat completions provider for local/model-server endpoints.
 - Codex CLI provider that can use local `codex exec` as the normal response engine.
-- Built-in tool registry with structured exception boundaries and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
+- Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `3`.
@@ -49,7 +49,8 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 ## Current Contract
 
 - High-risk tools require both capability enablement (matching allow flag, where applicable) and explicit approval for the exact tool-call ID and arguments before execution.
-- Cancelled runs must not transition to completed, blocked, or failed after cancellation.
+- Cancelled runs must not transition to completed, blocked, or failed after cancellation; lifecycle updates should use the guarded state transition helper.
+- Tool execution is bounded by `tool_timeout_seconds` / `NEST_AGENT_TOOL_TIMEOUT_SECONDS` and timeout failures are returned as structured tool errors.
 - Ordinary conversation and observations must not write policy memory directly.
 - The Memvid backend must use `.mv2` files and preserve one file per memory layer.
 - `complete.mv2` is a run artifact under `.nest/runs/{run_id}/`, not a permanent memory layer.

--- a/src/nested_memvid_agent/config.py
+++ b/src/nested_memvid_agent/config.py
@@ -44,6 +44,7 @@ class AgentConfig:
     channel_config_path: Path = Path(".nest/config/channels.json")
     enable_channel_delivery: bool = False
     channel_send_timeout_seconds: int = 10
+    tool_timeout_seconds: float = 30.0
 
     @classmethod
     def from_env(cls) -> AgentConfig:
@@ -69,6 +70,7 @@ class AgentConfig:
             channel_config_path=Path(os.getenv("NEST_AGENT_CHANNEL_CONFIG", ".nest/config/channels.json")),
             enable_channel_delivery=_env_bool("NEST_AGENT_ENABLE_CHANNEL_DELIVERY"),
             channel_send_timeout_seconds=_env_int("NEST_AGENT_CHANNEL_SEND_TIMEOUT_SECONDS", 10),
+            tool_timeout_seconds=_env_float("NEST_AGENT_TOOL_TIMEOUT_SECONDS", 30.0),
             allow_shell=_env_bool("NEST_AGENT_ALLOW_SHELL"),
             allow_file_write=_env_bool("NEST_AGENT_ALLOW_FILE_WRITE"),
             allow_policy_writes=_env_bool("NEST_AGENT_ALLOW_POLICY_WRITES"),

--- a/src/nested_memvid_agent/run_manager.py
+++ b/src/nested_memvid_agent/run_manager.py
@@ -121,7 +121,7 @@ class RunManager:
     def cancel_run(self, run_id: str) -> dict[str, Any]:
         with self._lock:
             self._cancelled.add(run_id)
-        run = self.state.update_run(run_id, status="cancelled", stop_reason="cancelled")
+        run = self.state.transition_run(run_id, "cancelled", stop_reason="cancelled")
         self.events.publish(run_id, "run.cancelled", {})
         return asdict(run)
 
@@ -141,7 +141,7 @@ class RunManager:
         if approved:
             self._resume_after_approval(updated, approved_arguments)
         else:
-            self.state.update_run(updated["run_id"], status="failed", error="Approval denied", stop_reason="approval_denied")
+            self.state.transition_run(updated["run_id"], "failed", error="Approval denied", stop_reason="approval_denied")
             self.events.publish(updated["run_id"], "run.failed", {"error": "Approval denied"})
         return updated
 
@@ -225,7 +225,7 @@ class RunManager:
     def _run_agent_turn(self, run_id: str, config: AgentConfig, message: str, session_id: str) -> None:
         if self._is_cancelled(run_id):
             return
-        self.state.update_run(run_id, status="running")
+        self.state.transition_run(run_id, "running")
         self.events.publish(run_id, "run.started", {"session_id": session_id})
         agent = self._build_agent(config)
         try:
@@ -247,9 +247,9 @@ class RunManager:
                     _execution_payload(execution),
                 )
             status = "blocked" if result.stop_reason == "approval_required" else "completed"
-            self.state.update_run(
+            self.state.transition_run(
                 run_id,
-                status=status,
+                status,
                 assistant_message=result.assistant_message,
                 context_chars=result.context_chars,
                 tool_count=len(result.tool_executions),
@@ -261,7 +261,7 @@ class RunManager:
         except Exception as exc:  # noqa: BLE001
             if self._is_cancelled(run_id):
                 return
-            self.state.update_run(run_id, status="failed", error=f"{type(exc).__name__}: {exc}", stop_reason="error")
+            self.state.transition_run(run_id, "failed", error=f"{type(exc).__name__}: {exc}", stop_reason="error")
             self.events.publish(run_id, "run.failed", {"error": f"{type(exc).__name__}: {exc}"})
         finally:
             agent.close()
@@ -272,7 +272,7 @@ class RunManager:
             return
         run = self.state.get_run(run_id)
         config = replace(self.config, workspace=Path(run.workspace), model=run.model)
-        self.state.update_run(run_id, status="running", stop_reason="resuming_after_approval")
+        self.state.transition_run(run_id, "running", stop_reason="resuming_after_approval")
         self._start_thread(run_id, self._run_approved_tool_then_continue, config, approval, arguments, run.session_id)
 
     def _run_approved_tool_then_continue(
@@ -325,9 +325,9 @@ class RunManager:
                 return
             self._publish_turn_observability(run_id, result)
             status = "blocked" if result.stop_reason == "approval_required" else "completed"
-            self.state.update_run(
+            self.state.transition_run(
                 run_id,
-                status=status,
+                status,
                 assistant_message=result.assistant_message,
                 context_chars=result.context_chars,
                 tool_count=len(result.tool_executions) + 1,
@@ -339,7 +339,7 @@ class RunManager:
         except Exception as exc:  # noqa: BLE001
             if self._is_cancelled(run_id):
                 return
-            self.state.update_run(run_id, status="failed", error=f"{type(exc).__name__}: {exc}", stop_reason="error")
+            self.state.transition_run(run_id, "failed", error=f"{type(exc).__name__}: {exc}", stop_reason="error")
             self.events.publish(run_id, "run.failed", {"error": f"{type(exc).__name__}: {exc}"})
         finally:
             agent.close()

--- a/src/nested_memvid_agent/state_store.py
+++ b/src/nested_memvid_agent/state_store.py
@@ -107,6 +107,28 @@ class AgentStateStore:
             conn.execute(f"UPDATE runs SET {assignments} WHERE run_id = ?", values)
         return self.get_run(run_id)
 
+    def transition_run(self, run_id: str, status: str, **fields: object) -> RunRecord:
+        """Apply a guarded run lifecycle transition.
+
+        Invalid transitions leave the current run untouched. This protects terminal
+        states like cancelled from late background completions or failures.
+        """
+        with self._connect() as conn:
+            current_row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+            if current_row is None:
+                raise KeyError(f"Unknown run: {run_id}")
+            current = _run_from_row(current_row)
+            if not _run_transition_allowed(current.status, status):
+                return current
+            updates = dict(fields)
+            updates["status"] = status
+            updates["updated_at"] = utc_now()
+            assignments = ", ".join(f"{key} = ?" for key in updates)
+            values = [_encode(value) for value in updates.values()]
+            values.append(run_id)
+            conn.execute(f"UPDATE runs SET {assignments} WHERE run_id = ?", values)
+        return self.get_run(run_id)
+
     def get_run(self, run_id: str) -> RunRecord:
         with self._connect() as conn:
             row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
@@ -693,6 +715,20 @@ def _apply_schema_v3(conn: sqlite3.Connection) -> None:
 
 def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _run_transition_allowed(current: str, target: str) -> bool:
+    allowed = {
+        "queued": {"running", "cancelled", "failed"},
+        "running": {"blocked", "completed", "failed", "cancelled"},
+        "blocked": {"running", "cancelled", "failed"},
+        "completed": set(),
+        "failed": set(),
+        "cancelled": set(),
+    }
+    if current == target:
+        return True
+    return target in allowed.get(current, set())
 
 
 def _run_from_row(row: sqlite3.Row) -> RunRecord:

--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from queue import Empty, Queue
+from threading import Thread
 from typing import Any
 
 from ..runtime_models import ToolCall, ToolExecution, ToolSpec
@@ -70,10 +72,25 @@ def _is_exact_call_approved(call: ToolCall, arguments: dict[str, Any], context: 
 
 
 def _run_tool(tool: AgentTool, call: ToolCall, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+    timeout = max(float(getattr(context.config, "tool_timeout_seconds", 30.0)), 0.001)
+    results: Queue[ToolExecution] = Queue(maxsize=1)
+
+    def target() -> None:
+        try:
+            results.put(tool.run(arguments, context))
+        except Exception as exc:  # noqa: BLE001 - registry boundary must never crash agent turns
+            results.put(_failure(call, content=f"{type(exc).__name__}: {exc}", error="tool_execution_failed"))
+
+    thread = Thread(target=target, daemon=True)
+    thread.start()
     try:
-        return tool.run(arguments, context)
-    except Exception as exc:  # noqa: BLE001 - registry boundary must never crash agent turns
-        return _failure(call, content=f"{type(exc).__name__}: {exc}", error="tool_execution_failed")
+        return results.get(timeout=timeout)
+    except Empty:
+        return _failure(
+            call,
+            content=f"Tool {call.name} timed out after {timeout:g} seconds.",
+            error="tool_timeout",
+        )
 
 
 def _failure(call: ToolCall, *, content: str, error: str) -> ToolExecution:

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -47,6 +47,32 @@ def test_state_store_tracks_runs_and_approvals(tmp_path: Path) -> None:
     assert decided["status"] == "approved"
 
 
+def test_state_store_enforces_run_lifecycle_transitions(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    state.create_run(
+        run_id="run_lifecycle",
+        message="hello",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+
+    running = state.transition_run("run_lifecycle", "running")
+    assert running.status == "running"
+    blocked = state.transition_run("run_lifecycle", "blocked", stop_reason="approval_required")
+    assert blocked.status == "blocked"
+    resumed = state.transition_run("run_lifecycle", "running", stop_reason="resuming_after_approval")
+    assert resumed.status == "running"
+    cancelled = state.transition_run("run_lifecycle", "cancelled", stop_reason="cancelled")
+    assert cancelled.status == "cancelled"
+
+    blocked_after_cancel = state.transition_run("run_lifecycle", "blocked", stop_reason="approval_required")
+    assert blocked_after_cancel.status == "cancelled"
+    completed_after_cancel = state.transition_run("run_lifecycle", "completed", stop_reason="complete")
+    assert completed_after_cancel.status == "cancelled"
+    assert completed_after_cancel.stop_reason == "cancelled"
+
+
 def test_state_store_lists_sessions_from_runs(tmp_path: Path) -> None:
     state = AgentStateStore(tmp_path / "state.db")
     state.create_run(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from time import sleep
 
 from pytest import MonkeyPatch
 
@@ -13,6 +14,38 @@ from nested_memvid_agent.runtime_models import ToolCall, ToolExecution, ToolSpec
 from nested_memvid_agent.tools.base import AgentTool, ToolContext
 from nested_memvid_agent.tools.builtin import build_default_tools
 from nested_memvid_agent.tools.registry import ToolRegistry
+
+
+class SlowTool(AgentTool):
+    spec = ToolSpec(
+        name="slow.tool",
+        description="Sleeps longer than the configured timeout.",
+        parameters={"type": "object", "properties": {}},
+    )
+
+    def run(self, arguments: dict[str, object], context: ToolContext) -> ToolExecution:
+        sleep(0.2)
+        return ToolExecution(
+            call=ToolCall(name=self.spec.name, arguments=arguments),
+            success=True,
+            content="finished",
+        )
+
+
+def test_tool_registry_times_out_slow_tools(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = ToolRegistry()
+    registry.register(SlowTool())
+    config = AgentConfig(tool_timeout_seconds=0.01)
+
+    result = registry.execute(
+        ToolCall(name="slow.tool", arguments={}),
+        ToolContext(memory=memory, config=config, workspace=tmp_path),
+    )
+
+    assert result.success is False
+    assert result.error == "tool_timeout"
+    assert "timed out" in result.content
 
 
 def test_memory_search_tool_returns_hits(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add guarded run lifecycle transitions in AgentStateStore and use them from RunManager
- add configurable tool timeout enforcement with structured tool_timeout failures
- document the updated runtime contract

## Test Plan
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"