### PR TITLE
feat: add self diagnosis primitives

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -15,6 +15,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - OpenAI-compatible chat completions provider for local/model-server endpoints.
 - Codex CLI provider that can use local `codex exec` as the normal response engine.
 - Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
+- Self-diagnosis primitives can classify common provider/tool/test/import/permission/MCP/sandbox failures and recall similar procedural/episodic failure lessons before retry.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `4`.
@@ -23,6 +24,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - MCP server records now track health metadata, tool counts, capabilities, last sync/seen/call/error timestamps, session state, failure counts, and latency.
 - MCP stdio servers now have a managed lazy session lifecycle with connect/disconnect/restart/health API routes, bounded operation timeouts, config-change teardown, and approval-by-default tool risk normalization.
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
+- Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
 
 ## Partially Implemented
 
@@ -31,6 +33,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Skills: filesystem discovery and skill tool adapters exist. Sandboxed skill execution and richer skill manifests remain incomplete.
 - Codex CLI: `codex-cli` can drive responses and `codex.exec` is available as a high-risk approval-gated tool. It is not yet a branch-isolated autonomous repair loop.
 - Consolidation: capsule extraction and Nested Learning decisions exist, but auto-consolidation remains disabled by default and validation loops are still basic.
+- Self-diagnosis: first-pass classification and memory recall tools exist. A full executor retry gate that forces changed strategy before every retry is still incomplete.
 - Self-modification: the runtime can record validated self-improvement signals and policy candidates, but code changes and policy writes still require explicit gates.
 - Subagents: local subagent runs can be queued and tracked. True branch/worktree isolation and Codex-backed worker fan-out are still next steps.
 - Channels: inbound normalization and dry-run reply payloads are implemented. Production bot identity verification, Discord Gateway reads, and channel-specific rate-limit handling still need hardening.

--- a/src/nested_memvid_agent/agent.py
+++ b/src/nested_memvid_agent/agent.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from .config import AgentConfig
 from .context_compiler import ContextCompiler, ContextCompilerConfig
 from .context_frames import MV2ContextFrame
+from .diagnosis import classify_failure
 from .event_log import AgentEvent, JsonlEventLog
 from .layers import LayeredMemorySystem
 from .llm.base import LLMProvider, ProviderError
@@ -166,6 +167,15 @@ class NestedMV2Agent:
                 error = _provider_error_payload(exc)
                 self._event("llm.error", {"session_id": session, "run_id": active_run_id, **error})
                 self._event("runtime.error", {"session_id": session, "run_id": active_run_id, **error})
+                self._event(
+                    "diagnosis.classified",
+                    {
+                        "session_id": session,
+                        "run_id": active_run_id,
+                        "source": "provider",
+                        **classify_failure(f"Provider error {error['code']}: {error['message']}", source="provider").to_payload(),
+                    },
+                )
                 failure_frame_id = f"{turn_frame_id}_provider_error"
                 child_frame_ids.append(failure_frame_id)
                 memory_writes.append(

--- a/src/nested_memvid_agent/diagnosis.py
+++ b/src/nested_memvid_agent/diagnosis.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FailureClassification:
+    category: str
+    confidence: float
+    signals: tuple[str, ...]
+    retryable: bool
+    playbook: dict[str, object]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "classification": self.category,
+            "confidence": self.confidence,
+            "signals": list(self.signals),
+            "retryable": self.retryable,
+            "playbook": self.playbook,
+        }
+
+
+def classify_failure(failure_text: str, *, source: str = "") -> FailureClassification:
+    text = failure_text.strip()
+    lowered = f"{source}\n{text}".lower()
+    signals: list[str] = []
+
+    if any(marker in lowered for marker in ("modulenotfounderror", "importerror", "no module named")):
+        signals.append("python import/dependency error marker")
+        return FailureClassification(
+            category="missing_dependency",
+            confidence=0.86,
+            signals=tuple(signals),
+            retryable=True,
+            playbook=_playbook("missing_dependency"),
+        )
+    if any(marker in lowered for marker in ("failed tests/", " assertionerror", "pytest", "== failures ==")):
+        signals.append("pytest/test failure marker")
+        return FailureClassification(
+            category="test_failure",
+            confidence=0.82,
+            signals=tuple(signals),
+            retryable=True,
+            playbook=_playbook("test_failure"),
+        )
+    if any(marker in lowered for marker in ("permission denied", "operation not permitted", "approval_required")):
+        signals.append("permission/approval marker")
+        return FailureClassification(
+            category="permission_failure",
+            confidence=0.78,
+            signals=tuple(signals),
+            retryable=False,
+            playbook=_playbook("permission_failure"),
+        )
+    if any(marker in lowered for marker in ("invalid_tool_arguments", "bad_memory_enum", "unknown memory layer")):
+        signals.append("tool argument validation marker")
+        return FailureClassification(
+            category="bad_tool_args",
+            confidence=0.8,
+            signals=tuple(signals),
+            retryable=True,
+            playbook=_playbook("bad_tool_args"),
+        )
+    if any(marker in lowered for marker in ("tool_timeout", "timed out", "timeout")):
+        signals.append("timeout marker")
+        return FailureClassification(
+            category="tool_failure",
+            confidence=0.72,
+            signals=tuple(signals),
+            retryable=True,
+            playbook=_playbook("tool_failure"),
+        )
+    if any(marker in lowered for marker in ("provider error", "rate limit", "openai", "anthropic", "llm.error")):
+        signals.append("provider failure marker")
+        return FailureClassification(
+            category="provider_failure",
+            confidence=0.7,
+            signals=tuple(signals),
+            retryable=True,
+            playbook=_playbook("provider_failure"),
+        )
+    if any(marker in lowered for marker in ("mcp", "json-rpc", "stdio server", "sse")):
+        signals.append("mcp/transport marker")
+        return FailureClassification(
+            category="mcp_failure",
+            confidence=0.68,
+            signals=tuple(signals),
+            retryable=True,
+            playbook=_playbook("mcp_failure"),
+        )
+    if any(marker in lowered for marker in ("path escapes workspace", "sandbox", "outside workspace")):
+        signals.append("path/sandbox marker")
+        return FailureClassification(
+            category="path_sandbox_violation",
+            confidence=0.84,
+            signals=tuple(signals),
+            retryable=False,
+            playbook=_playbook("path_sandbox_violation"),
+        )
+
+    return FailureClassification(
+        category="unknown_failure",
+        confidence=0.35,
+        signals=tuple(signals),
+        retryable=True,
+        playbook=_playbook("unknown_failure"),
+    )
+
+
+def _playbook(category: str) -> dict[str, object]:
+    playbooks: dict[str, dict[str, object]] = {
+        "test_failure": {
+            "name": "Test failure playbook",
+            "next_actions": [
+                "Read the first failing assertion and stack trace completely.",
+                "Run the smallest failing test target to reproduce.",
+                "Inspect recent changes around the failing code path.",
+                "Fix the root cause, then run targeted tests before broader tests.",
+            ],
+        },
+        "missing_dependency": {
+            "name": "Import/dependency failure playbook",
+            "next_actions": [
+                "Identify whether the missing module is first-party or third-party.",
+                "For first-party imports, verify PYTHONPATH/package configuration before installing anything.",
+                "For third-party imports, update project dependency metadata rather than ad-hoc CI installs.",
+            ],
+        },
+        "provider_failure": {
+            "name": "Provider failure playbook",
+            "next_actions": [
+                "Classify retryable versus configuration/auth failure.",
+                "Check provider timeout, rate-limit, and credential settings.",
+                "Preserve the provider error taxonomy in the run trace.",
+            ],
+        },
+        "mcp_failure": {
+            "name": "MCP failure playbook",
+            "next_actions": [
+                "Check transport health and last error metadata.",
+                "Retry connection once with timeout boundaries.",
+                "Do not trust new MCP tools without risk classification and approval.",
+            ],
+        },
+        "bad_tool_args": {
+            "name": "Bad tool arguments playbook",
+            "next_actions": [
+                "Compare arguments to the tool schema.",
+                "Correct only the malformed fields before retrying.",
+                "Record repeated schema mistakes as procedural candidates after validation.",
+            ],
+        },
+        "tool_failure": {
+            "name": "Tool failure playbook",
+            "next_actions": [
+                "Inspect tool exit code/error and timeout boundary.",
+                "Retry only if the strategy changes or the failure is transient.",
+                "Prefer narrower commands before broad retries.",
+            ],
+        },
+        "permission_failure": {
+            "name": "Permission failure playbook",
+            "next_actions": [
+                "Do not bypass approval or sandbox policy.",
+                "Request the minimum explicit permission needed for the exact action.",
+            ],
+        },
+        "path_sandbox_violation": {
+            "name": "Path/sandbox violation playbook",
+            "next_actions": [
+                "Stop the attempted path escape.",
+                "Resolve files relative to the configured workspace.",
+                "Ask for explicit scope expansion if the file is truly outside the workspace.",
+            ],
+        },
+        "unknown_failure": {
+            "name": "Unknown failure playbook",
+            "next_actions": [
+                "Gather the complete error text and reproduction command.",
+                "Classify the failing component before retrying.",
+                "Avoid repeating the same action without a changed hypothesis.",
+            ],
+        },
+    }
+    return playbooks[category]

--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -9,6 +9,7 @@ from typing import Any
 from ..consolidation import Consolidator
 from ..context_frames import default_frame_type_for_memory, estimate_tokens, from_memory_record
 from ..context_packer import ContextPacker, ContextPackRequest
+from ..diagnosis import classify_failure
 from ..models import MemoryKind, MemoryLayer, MemoryRecord, RetrievalQuery
 from ..nested_learning import LearningSignal, NestedLearningKernel
 from ..runtime_models import ToolCall, ToolExecution, ToolSpec
@@ -1291,8 +1292,93 @@ class MemoryImportTool(AgentTool):
         return self._result(call, success=True, content=json.dumps(payload, indent=2), data=payload)
 
 
+class DiagnosisClassifyTool(AgentTool):
+    spec = ToolSpec(
+        name="diagnosis.classify",
+        description="Classify a runtime/tool/test/provider failure and return the matching diagnostic playbook.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "failure_text": {"type": "string"},
+                "source": {"type": "string"},
+            },
+            "required": ["failure_text"],
+        },
+        capabilities=("self-diagnosis", "failure-classification"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        del context
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        failure_text = str(arguments.get("failure_text", "")).strip()
+        if not failure_text:
+            return self._result(call, success=False, content="Missing failure_text", error="missing_failure_text")
+        classification = classify_failure(failure_text, source=str(arguments.get("source", "")))
+        payload = classification.to_payload()
+        content = json.dumps(payload, indent=2)
+        return self._result(call, success=True, content=content, data=payload)
+
+
+class DiagnosisRecallTool(AgentTool):
+    spec = ToolSpec(
+        name="diagnosis.recall",
+        description="Classify a failure and retrieve similar prior failure lessons from procedural/episodic memory before retrying.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "failure_text": {"type": "string"},
+                "source": {"type": "string"},
+                "k": {"type": "integer", "minimum": 1, "maximum": 10},
+            },
+            "required": ["failure_text"],
+        },
+        capabilities=("self-diagnosis", "failure-recall", "nested-memory"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        failure_text = str(arguments.get("failure_text", "")).strip()
+        if not failure_text:
+            return self._result(call, success=False, content="Missing failure_text", error="missing_failure_text")
+        classification = classify_failure(failure_text, source=str(arguments.get("source", "")))
+        k = max(1, min(int(arguments.get("k", 5)), 10))
+        query = f"{classification.category} {failure_text}"
+        hits = context.memory.retrieve(
+            RetrievalQuery(
+                query=query,
+                layers=(MemoryLayer.PROCEDURAL, MemoryLayer.EPISODIC, MemoryLayer.WORKING),
+                k_per_layer=k,
+            )
+        )
+        rows = []
+        for hit in hits[:k]:
+            rows.append(
+                {
+                    "layer": hit.record.layer.value,
+                    "kind": hit.record.kind.value,
+                    "title": hit.record.title,
+                    "score": hit.score,
+                    "snippet": hit.snippet or hit.record.content[:500],
+                }
+            )
+        payload = {
+            **classification.to_payload(),
+            "query": query,
+            "hits": rows,
+            "retry_guidance": {
+                "must_change_strategy_before_retry": bool(rows),
+                "reason": "Similar prior failures were found; use recalled lessons before repeating the action."
+                if rows
+                else "No prior lesson found; follow the diagnostic playbook and record validated findings.",
+            },
+        }
+        return self._result(call, success=True, content=json.dumps(payload, indent=2), data=payload)
+
+
 def build_default_tools() -> ToolRegistry:
     registry = ToolRegistry()
+    registry.register(DiagnosisClassifyTool())
+    registry.register(DiagnosisRecallTool())
     registry.register(MemorySearchTool())
     registry.register(MemoryWriteTool())
     registry.register(ContextPackTool())

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -176,6 +176,9 @@ def test_provider_failure_is_structured_logged_and_remembered(tmp_path: Path) ->
     event_types = [event.type for event in event_log.tail(limit=50)]
     assert "llm.error" in event_types
     assert "runtime.error" in event_types
+    diagnosis_events = [event for event in event_log.tail(limit=50) if event.type == "diagnosis.classified"]
+    assert diagnosis_events
+    assert diagnosis_events[0].payload["classification"] == "provider_failure"
 
 
 class FailingProvider(LLMProvider):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -181,10 +181,58 @@ def test_tool_exception_returns_structured_failure(tmp_path: Path) -> None:
     assert "RuntimeError: boom" in result.content
 
 
+def test_diagnosis_classify_identifies_test_failures(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+
+    result = registry.execute(
+        ToolCall(
+            name="diagnosis.classify",
+            arguments={
+                "failure_text": "FAILED tests/test_api.py::test_login - AssertionError: expected 200 got 500",
+                "source": "pytest",
+            },
+        ),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+
+    assert result.success
+    assert result.data["classification"] == "test_failure"
+    assert "test failure playbook" in result.content.lower()
+    assert result.data["playbook"]["next_actions"]
+
+
+def test_diagnosis_recall_searches_prior_failure_lessons(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    memory.put(
+        MemoryRecord(
+            layer=MemoryLayer.PROCEDURAL,
+            kind=MemoryKind.PROCEDURE,
+            title="ImportError repair recipe",
+            content="When pytest reports ModuleNotFoundError for nested_memvid_agent, set PYTHONPATH=src before retrying.",
+            confidence=0.9,
+        )
+    )
+    registry = build_default_tools()
+
+    result = registry.execute(
+        ToolCall(name="diagnosis.recall", arguments={"failure_text": "ModuleNotFoundError: nested_memvid_agent", "k": 3}),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+
+    assert result.success
+    assert result.data["classification"] == "missing_dependency"
+    assert result.data["hits"]
+    assert result.data["hits"][0]["layer"] == "procedural"
+    assert "PYTHONPATH=src" in result.content
+
+
 def test_default_registry_includes_spec_tools() -> None:
     registry = build_default_tools()
     names = {spec.name for spec in registry.specs()}
     assert {
+        "diagnosis.classify",
+        "diagnosis.recall",
         "repo.search",
         "repo.map",
         "patch.apply",


### PR DESCRIPTION
## Summary
- add failure classifier/playbooks for test, import/dependency, provider, tool, permission, MCP, and sandbox failures
- expose diagnosis.classify and diagnosis.recall tools in the default registry
- emit diagnosis.classified events for provider failures and document Phase 3 status

## Validation
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"