### PR TITLE
feat: add repair branch preparation

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -16,6 +16,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Codex CLI provider that can use local `codex exec` as the normal response engine.
 - Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Self-diagnosis primitives can classify common provider/tool/test/import/permission/MCP/sandbox failures and recall similar procedural/episodic failure lessons before retry.
+- Safe self-repair now has a first branch-isolation primitive: `repair.prepare` records the base SHA and switches to an approved repair branch only from a clean worktree.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `4`.
@@ -25,6 +26,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - MCP stdio servers now have a managed lazy session lifecycle with connect/disconnect/restart/health API routes, bounded operation timeouts, config-change teardown, and approval-by-default tool risk normalization.
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
+- `repair.prepare` is high-risk, approval-gated, covered by exact-call approvals, and disabled unless file-write capability is enabled.
 
 ## Partially Implemented
 
@@ -35,6 +37,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Consolidation: capsule extraction and Nested Learning decisions exist, but auto-consolidation remains disabled by default and validation loops are still basic.
 - Self-diagnosis: first-pass classification and memory recall tools exist. A full executor retry gate that forces changed strategy before every retry is still incomplete.
 - Self-modification: the runtime can record validated self-improvement signals and policy candidates, but code changes and policy writes still require explicit gates.
+- Safe repair: repair branch preparation exists, but full patch/test/review/rollback orchestration and approval-before-commit workflow are still incomplete.
 - Subagents: local subagent runs can be queued and tracked. True branch/worktree isolation and Codex-backed worker fan-out are still next steps.
 - Channels: inbound normalization and dry-run reply payloads are implemented. Production bot identity verification, Discord Gateway reads, and channel-specific rate-limit handling still need hardening.
 

--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -875,6 +875,98 @@ class LintRunTool(AgentTool):
             return self._result(call, success=False, content=str(exc), error="lint_run_failed")
 
 
+class RepairPrepareTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.prepare",
+        description="Prepare an isolated repair branch from the current clean workspace and record the base SHA. Requires approval.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "branch": {"type": "string"},
+                "allow_dirty": {"type": "boolean"},
+            },
+            "required": ["branch"],
+        },
+        risk="high",
+        requires_approval=True,
+        capabilities=("safe-repair", "git-isolation"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        branch = str(arguments.get("branch", "")).strip()
+        if not branch:
+            return self._result(call, success=False, content="Missing branch", error="missing_branch")
+        if not _safe_branch_name(branch):
+            return self._result(call, success=False, content=f"Unsafe branch name: {branch}", error="unsafe_branch_name")
+        try:
+            base = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=context.workspace,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if base.returncode != 0:
+                return self._result(
+                    call,
+                    success=False,
+                    content=f"Unable to resolve base SHA. STDERR:\n{base.stderr}",
+                    error="git_base_failed",
+                    data={"returncode": base.returncode},
+                )
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=context.workspace,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if status.returncode != 0:
+                return self._result(
+                    call,
+                    success=False,
+                    content=f"Unable to inspect worktree. STDERR:\n{status.stderr}",
+                    error="git_status_failed",
+                    data={"returncode": status.returncode},
+                )
+            if status.stdout.strip() and not bool(arguments.get("allow_dirty", False)):
+                return self._result(
+                    call,
+                    success=False,
+                    content="Refusing to prepare repair branch with uncommitted changes.",
+                    error="dirty_worktree",
+                    data={"dirty_status": status.stdout},
+                )
+            created = subprocess.run(
+                ["git", "switch", "-c", branch],
+                cwd=context.workspace,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            content = f"exit_code={created.returncode}\nSTDOUT:\n{created.stdout}\nSTDERR:\n{created.stderr}"
+            success = created.returncode == 0
+            return self._result(
+                call,
+                success=success,
+                content=content,
+                data={
+                    "mode": "branch",
+                    "branch": branch,
+                    "base_sha": base.stdout.strip(),
+                    "returncode": created.returncode,
+                    "approval_required_before_commit": True,
+                },
+                error=None if success else "repair_prepare_failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_prepare_failed")
+
+
 class GitStatusTool(AgentTool):
     spec = ToolSpec(
         name="git.status",
@@ -1379,6 +1471,7 @@ def build_default_tools() -> ToolRegistry:
     registry = ToolRegistry()
     registry.register(DiagnosisClassifyTool())
     registry.register(DiagnosisRecallTool())
+    registry.register(RepairPrepareTool())
     registry.register(MemorySearchTool())
     registry.register(MemoryWriteTool())
     registry.register(ContextPackTool())
@@ -1409,6 +1502,15 @@ def build_default_tools() -> ToolRegistry:
     registry.register(MemoryExportTool())
     registry.register(MemoryImportTool())
     return registry
+
+
+def _safe_branch_name(name: str) -> bool:
+    if not name or name.startswith(("-", "/")) or name.endswith(("/", ".", ".lock")):
+        return False
+    if ".." in name or "//" in name or "@{" in name or "\\" in name:
+        return False
+    allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._/-")
+    return all(char in allowed for char in name)
 
 
 def _safe_path(root: Path, relative: str) -> Path:

--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -103,5 +103,6 @@ _ENABLEMENT_BY_TOOL = {
     "shell.run": "allow_shell",
     "test.run": "allow_shell",
     "lint.run": "allow_shell",
+    "repair.prepare": "allow_file_write",
     "codex.exec": "allow_codex_cli",
 }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -227,10 +227,89 @@ def test_diagnosis_recall_searches_prior_failure_lessons(tmp_path: Path) -> None
     assert "PYTHONPATH=src" in result.content
 
 
+def test_repair_prepare_requires_approval_even_when_file_write_enabled(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+
+    result = registry.execute(
+        ToolCall(name="repair.prepare", arguments={"branch": "codex/repair-test"}, id="repair1"),
+        ToolContext(memory=memory, config=AgentConfig(allow_file_write=True), workspace=tmp_path),
+    )
+
+    assert not result.success
+    assert result.error == "approval_required"
+
+
+def test_repair_prepare_creates_approved_branch_from_clean_repo(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(name="repair.prepare", arguments={"branch": "codex/repair-test"}, id="repair_prepare")
+
+    result = registry.execute(
+        call,
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_file_write=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"repair_prepare"}),
+            approved_tool_call_arguments={"repair_prepare": {"branch": "codex/repair-test"}},
+        ),
+    )
+
+    assert result.success
+    assert result.data["branch"] == "codex/repair-test"
+    assert result.data["base_sha"]
+    assert result.data["mode"] == "branch"
+    current = subprocess.run(["git", "branch", "--show-current"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    assert current.stdout.strip() == "codex/repair-test"
+
+
+def test_repair_prepare_refuses_dirty_repo_by_default(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (tmp_path / "dirty.txt").write_text("uncommitted\n")
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(name="repair.prepare", arguments={"branch": "codex/dirty-test"}, id="repair_dirty")
+
+    result = registry.execute(
+        call,
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_file_write=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"repair_dirty"}),
+            approved_tool_call_arguments={"repair_dirty": {"branch": "codex/dirty-test"}},
+        ),
+    )
+
+    assert not result.success
+    assert result.error == "dirty_worktree"
+
+
 def test_default_registry_includes_spec_tools() -> None:
     registry = build_default_tools()
     names = {spec.name for spec in registry.specs()}
     assert {
+        "repair.prepare",
         "diagnosis.classify",
         "diagnosis.recall",
         "repo.search",


### PR DESCRIPTION
## Summary
- add approval-gated repair.prepare tool for safe repair branch preparation
- require clean worktree by default and return base SHA/branch metadata for repair traces
- gate repair.prepare behind file-write capability and cover exact-call approval behavior

## Validation
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"