### PR TITLE
feat: add repair pipeline primitives

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -16,7 +16,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Codex CLI provider that can use local `codex exec` as the normal response engine.
 - Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Self-diagnosis primitives can classify common provider/tool/test/import/permission/MCP/sandbox failures and recall similar procedural/episodic failure lessons before retry.
-- Safe self-repair now has a first branch-isolation primitive: `repair.prepare` records the base SHA and switches to an approved repair branch only from a clean worktree.
+- Safe self-repair now has branch-isolated repair primitives: `repair.prepare`, `repair.status`, `repair.apply_patch`, `repair.validate`, and `repair.rollback`.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `4`.
@@ -26,7 +26,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - MCP stdio servers now have a managed lazy session lifecycle with connect/disconnect/restart/health API routes, bounded operation timeouts, config-change teardown, and approval-by-default tool risk normalization.
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
-- `repair.prepare` is high-risk, approval-gated, covered by exact-call approvals, and disabled unless file-write capability is enabled.
+- Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 
 ## Partially Implemented
 
@@ -37,7 +37,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Consolidation: capsule extraction and Nested Learning decisions exist, but auto-consolidation remains disabled by default and validation loops are still basic.
 - Self-diagnosis: first-pass classification and memory recall tools exist. A full executor retry gate that forces changed strategy before every retry is still incomplete.
 - Self-modification: the runtime can record validated self-improvement signals and policy candidates, but code changes and policy writes still require explicit gates.
-- Safe repair: repair branch preparation exists, but full patch/test/review/rollback orchestration and approval-before-commit workflow are still incomplete.
+- Safe repair: branch preparation, patch application, targeted validation, status reporting, and rollback primitives exist. Full autonomous patch proposal, reviewer gating, and approval-before-commit orchestration are still incomplete.
 - Subagents: local subagent runs can be queued and tracked. True branch/worktree isolation and Codex-backed worker fan-out are still next steps.
 - Channels: inbound normalization and dry-run reply payloads are implemented. Production bot identity verification, Discord Gateway reads, and channel-specific rate-limit handling still need hardening.
 

--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -967,6 +967,173 @@ class RepairPrepareTool(AgentTool):
             return self._result(call, success=False, content=str(exc), error="repair_prepare_failed")
 
 
+class RepairStatusTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.status",
+        description="Report whether the workspace is on a repair branch, changed files, and optional base SHA trace metadata.",
+        parameters={
+            "type": "object",
+            "properties": {"base_sha": {"type": "string"}},
+        },
+        capabilities=("safe-repair", "git-isolation"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        try:
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            head = _git_output(context.workspace, ["git", "rev-parse", "HEAD"])
+            status = _git_output(context.workspace, ["git", "status", "--porcelain"])
+            changed_files = _changed_files_from_status(status)
+            base_sha = str(arguments.get("base_sha", "")).strip() or None
+            payload = {
+                "branch": branch,
+                "head_sha": head,
+                "base_sha": base_sha,
+                "active_repair_branch": _is_repair_branch(branch),
+                "dirty": bool(status.strip()),
+                "changed_files": changed_files,
+                "raw_status": status,
+            }
+            return self._result(call, success=True, content=json.dumps(payload, indent=2), data=payload)
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_status_failed")
+
+
+class RepairApplyPatchTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.apply_patch",
+        description="Apply a repair patch only while on an active repair branch. Requires approval and file-write capability.",
+        parameters={
+            "type": "object",
+            "properties": {"patch": {"type": "string"}, "check": {"type": "boolean"}},
+            "required": ["patch"],
+        },
+        risk="high",
+        requires_approval=True,
+        capabilities=("safe-repair", "patching"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        patch_text = str(arguments.get("patch", ""))
+        if not patch_text.strip():
+            return self._result(call, success=False, content="Missing patch", error="missing_patch")
+        try:
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            if not _is_repair_branch(branch):
+                return self._result(
+                    call,
+                    success=False,
+                    content=f"Refusing to apply repair patch on non-repair branch: {branch}",
+                    error="not_repair_branch",
+                    data={"branch": branch},
+                )
+            _validate_patch_paths(context.workspace, patch_text)
+            command = ["git", "apply", "--check"] if bool(arguments.get("check", False)) else ["git", "apply", "--whitespace=nowarn"]
+            completed = subprocess.run(
+                command,
+                cwd=context.workspace,
+                input=patch_text,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            content = f"exit_code={completed.returncode}\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+            return self._result(
+                call,
+                success=completed.returncode == 0,
+                content=content,
+                data={"branch": branch, "returncode": completed.returncode, "check": bool(arguments.get("check", False))},
+                error=None if completed.returncode == 0 else "repair_patch_failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_patch_failed")
+
+
+class RepairValidateTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.validate",
+        description="Run a bounded repair validation command on an active repair branch and classify failures.",
+        parameters={
+            "type": "object",
+            "properties": {"command": {"type": "array", "items": {"type": "string"}}, "timeout": {"type": "integer"}},
+            "required": ["command"],
+        },
+        risk="high",
+        requires_approval=True,
+        capabilities=("safe-repair", "validation", "self-diagnosis"),
+    )
+    allowed_first_tokens = {"pytest", "python", "python3", "ruff", "mypy"}
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        command_raw = arguments.get("command")
+        if not isinstance(command_raw, list) or not all(isinstance(item, str) for item in command_raw):
+            return self._result(call, success=False, content="command must be list[str]", error="bad_command")
+        command = list(command_raw)
+        if not command or Path(command[0]).name not in self.allowed_first_tokens:
+            return self._result(call, success=False, content="Command is not allowlisted", error="command_not_allowlisted")
+        try:
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            if not _is_repair_branch(branch):
+                return self._result(call, success=False, content=f"Not on a repair branch: {branch}", error="not_repair_branch")
+            completed = subprocess.run(
+                command,
+                cwd=context.workspace,
+                capture_output=True,
+                text=True,
+                timeout=int(arguments.get("timeout", 120)),
+                check=False,
+            )
+            content = f"exit_code={completed.returncode}\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+            diagnosis = classify_failure(content, source="repair.validate").to_payload() if completed.returncode != 0 else None
+            return self._result(
+                call,
+                success=completed.returncode == 0,
+                content=content,
+                data={"branch": branch, "returncode": completed.returncode, "diagnosis": diagnosis},
+                error=None if completed.returncode == 0 else "repair_validation_failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_validation_failed")
+
+
+class RepairRollbackTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.rollback",
+        description="Rollback uncommitted changes on an active repair branch. Requires approval and never runs on main/master.",
+        parameters={"type": "object", "properties": {}},
+        risk="high",
+        requires_approval=True,
+        capabilities=("safe-repair", "rollback"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        try:
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            if not _is_repair_branch(branch):
+                return self._result(call, success=False, content=f"Not on a repair branch: {branch}", error="not_repair_branch")
+            reset = subprocess.run(["git", "checkout", "--", "."], cwd=context.workspace, capture_output=True, text=True, timeout=30, check=False)
+            clean = subprocess.run(["git", "clean", "-fd"], cwd=context.workspace, capture_output=True, text=True, timeout=30, check=False)
+            success = reset.returncode == 0 and clean.returncode == 0
+            content = (
+                f"reset_exit_code={reset.returncode}\nRESET_STDOUT:\n{reset.stdout}\nRESET_STDERR:\n{reset.stderr}\n"
+                f"clean_exit_code={clean.returncode}\nCLEAN_STDOUT:\n{clean.stdout}\nCLEAN_STDERR:\n{clean.stderr}"
+            )
+            return self._result(
+                call,
+                success=success,
+                content=content,
+                data={"branch": branch, "reset_returncode": reset.returncode, "clean_returncode": clean.returncode},
+                error=None if success else "repair_rollback_failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_rollback_failed")
+
+
 class GitStatusTool(AgentTool):
     spec = ToolSpec(
         name="git.status",
@@ -1472,6 +1639,10 @@ def build_default_tools() -> ToolRegistry:
     registry.register(DiagnosisClassifyTool())
     registry.register(DiagnosisRecallTool())
     registry.register(RepairPrepareTool())
+    registry.register(RepairStatusTool())
+    registry.register(RepairApplyPatchTool())
+    registry.register(RepairValidateTool())
+    registry.register(RepairRollbackTool())
     registry.register(MemorySearchTool())
     registry.register(MemoryWriteTool())
     registry.register(ContextPackTool())
@@ -1511,6 +1682,36 @@ def _safe_branch_name(name: str) -> bool:
         return False
     allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._/-")
     return all(char in allowed for char in name)
+
+
+def _is_repair_branch(name: str) -> bool:
+    return name.startswith(("codex/", "repair/", "fix/")) and name not in {"main", "master"}
+
+
+def _git_output(workspace: Path, command: list[str]) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"git command failed ({completed.returncode}): {' '.join(command)}\n{completed.stderr}")
+    return completed.stdout.strip()
+
+
+def _changed_files_from_status(status: str) -> list[str]:
+    files: list[str] = []
+    for line in status.splitlines():
+        if not line:
+            continue
+        path = line[3:] if len(line) > 3 and line[2] == " " else line[2:]
+        if " -> " in path:
+            path = path.split(" -> ", maxsplit=1)[1]
+        files.append(path.strip())
+    return files
 
 
 def _safe_path(root: Path, relative: str) -> Path:

--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -104,5 +104,8 @@ _ENABLEMENT_BY_TOOL = {
     "test.run": "allow_shell",
     "lint.run": "allow_shell",
     "repair.prepare": "allow_file_write",
+    "repair.apply_patch": "allow_file_write",
+    "repair.validate": "allow_shell",
+    "repair.rollback": "allow_file_write",
     "codex.exec": "allow_codex_cli",
 }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -240,30 +240,40 @@ def test_repair_prepare_requires_approval_even_when_file_write_enabled(tmp_path:
     assert result.error == "approval_required"
 
 
-def test_repair_prepare_creates_approved_branch_from_clean_repo(tmp_path: Path) -> None:
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
-    (tmp_path / "README.md").write_text("seed\n")
-    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
+def _init_git_repo(path: Path) -> str:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    (path / "README.md").write_text("seed\n")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(
         ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed"],
-        cwd=tmp_path,
+        cwd=path,
         check=True,
         capture_output=True,
         text=True,
     )
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=path, check=True, capture_output=True, text=True)
+    return base.stdout.strip()
+
+
+def _approved_context(memory: object, tmp_path: Path, call: ToolCall, *, allow_shell: bool = False) -> ToolContext:
+    return ToolContext(
+        memory=memory,  # type: ignore[arg-type]
+        config=AgentConfig(allow_file_write=True, allow_shell=allow_shell),
+        workspace=tmp_path,
+        approved_tool_call_ids=frozenset({call.id}),
+        approved_tool_call_arguments={call.id: call.arguments},
+    )
+
+
+def test_repair_prepare_creates_approved_branch_from_clean_repo(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
     memory = build_memory_system("memory", tmp_path / "memory")
     registry = build_default_tools()
     call = ToolCall(name="repair.prepare", arguments={"branch": "codex/repair-test"}, id="repair_prepare")
 
     result = registry.execute(
         call,
-        ToolContext(
-            memory=memory,
-            config=AgentConfig(allow_file_write=True),
-            workspace=tmp_path,
-            approved_tool_call_ids=frozenset({"repair_prepare"}),
-            approved_tool_call_arguments={"repair_prepare": {"branch": "codex/repair-test"}},
-        ),
+        _approved_context(memory, tmp_path, call),
     )
 
     assert result.success
@@ -275,16 +285,7 @@ def test_repair_prepare_creates_approved_branch_from_clean_repo(tmp_path: Path) 
 
 
 def test_repair_prepare_refuses_dirty_repo_by_default(tmp_path: Path) -> None:
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
-    (tmp_path / "README.md").write_text("seed\n")
-    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
-    subprocess.run(
-        ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed"],
-        cwd=tmp_path,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    _init_git_repo(tmp_path)
     (tmp_path / "dirty.txt").write_text("uncommitted\n")
     memory = build_memory_system("memory", tmp_path / "memory")
     registry = build_default_tools()
@@ -292,17 +293,76 @@ def test_repair_prepare_refuses_dirty_repo_by_default(tmp_path: Path) -> None:
 
     result = registry.execute(
         call,
-        ToolContext(
-            memory=memory,
-            config=AgentConfig(allow_file_write=True),
-            workspace=tmp_path,
-            approved_tool_call_ids=frozenset({"repair_dirty"}),
-            approved_tool_call_arguments={"repair_dirty": {"branch": "codex/dirty-test"}},
-        ),
+        _approved_context(memory, tmp_path, call),
     )
 
     assert not result.success
     assert result.error == "dirty_worktree"
+
+
+def test_repair_status_reports_active_repair_branch_and_changed_files(tmp_path: Path) -> None:
+    base = _init_git_repo(tmp_path)
+    subprocess.run(["git", "switch", "-c", "codex/repair-status"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("changed\n")
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+
+    result = registry.execute(
+        ToolCall(name="repair.status", arguments={"base_sha": base}),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+
+    assert result.success
+    assert result.data["active_repair_branch"] is True
+    assert result.data["branch"] == "codex/repair-status"
+    assert result.data["base_sha"] == base
+    assert "README.md" in result.data["changed_files"]
+
+
+def test_repair_apply_patch_refuses_non_repair_branch(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(
+        name="repair.apply_patch",
+        arguments={"patch": "--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-seed\n+patched\n"},
+        id="repair_apply_main",
+    )
+
+    result = registry.execute(call, _approved_context(memory, tmp_path, call))
+
+    assert not result.success
+    assert result.error == "not_repair_branch"
+    assert (tmp_path / "README.md").read_text() == "seed\n"
+
+
+def test_repair_apply_validate_and_rollback_on_repair_branch(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "switch", "-c", "codex/repair-apply"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    patch_text = "--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-seed\n+patched\n"
+    apply_call = ToolCall(name="repair.apply_patch", arguments={"patch": patch_text}, id="repair_apply")
+
+    applied = registry.execute(apply_call, _approved_context(memory, tmp_path, apply_call))
+
+    assert applied.success
+    assert (tmp_path / "README.md").read_text() == "patched\n"
+
+    validate_call = ToolCall(
+        name="repair.validate",
+        arguments={"command": ["python", "-c", "import sys; print('bad'); sys.exit(2)"]},
+        id="repair_validate",
+    )
+    validated = registry.execute(validate_call, _approved_context(memory, tmp_path, validate_call, allow_shell=True))
+    assert not validated.success
+    assert validated.error == "repair_validation_failed"
+    assert validated.data["diagnosis"]["classification"] in {"tool_failure", "unknown_failure"}
+
+    rollback_call = ToolCall(name="repair.rollback", arguments={}, id="repair_rollback")
+    rolled_back = registry.execute(rollback_call, _approved_context(memory, tmp_path, rollback_call))
+    assert rolled_back.success
+    assert (tmp_path / "README.md").read_text() == "seed\n"
 
 
 def test_default_registry_includes_spec_tools() -> None:
@@ -310,6 +370,10 @@ def test_default_registry_includes_spec_tools() -> None:
     names = {spec.name for spec in registry.specs()}
     assert {
         "repair.prepare",
+        "repair.status",
+        "repair.apply_patch",
+        "repair.validate",
+        "repair.rollback",
         "diagnosis.classify",
         "diagnosis.recall",
         "repo.search",


### PR DESCRIPTION
## Summary
- add repair.status, repair.apply_patch, repair.validate, and repair.rollback tools
- require repair branches for repair patch/validate/rollback operations
- keep mutation tools approval-gated and capability-gated

## Validation
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"