### PR TITLE
feat: add provider capability fallback

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -14,6 +14,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - OpenAI Responses provider adapter using the portable JSON tool envelope.
 - OpenAI-compatible chat completions provider for local/model-server endpoints.
 - Codex CLI provider that can use local `codex exec` as the normal response engine.
+- Provider capability metadata is exposed on built-in providers, and a retryable-error fallback wrapper can route from a primary provider to a configured secondary provider.
 - Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Self-diagnosis primitives can classify common provider/tool/test/import/permission/MCP/sandbox failures and recall similar procedural/episodic failure lessons before retry.
 - Safe self-repair now has branch-isolated repair primitives: `repair.prepare`, `repair.status`, `repair.apply_patch`, `repair.validate`, and `repair.rollback`.
@@ -30,7 +31,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 
 ## Partially Implemented
 
-- Streaming: the runtime, CLI, and web run event bus accept stream events. Providers without native streaming use the compatibility wrapper around `generate()`.
+- Streaming/provider parity: the runtime, CLI, and web run event bus accept stream events, and provider capability metadata exists. Native streaming deltas and richer per-provider context/JSON-mode details still need hardening.
 - MCP: stdio live sessions are hardened and covered by a flag-gated integration test. SSE and streamable HTTP use the same manager path but still need real transport fixtures and production soak testing.
 - Skills: filesystem discovery and skill tool adapters exist. Sandboxed skill execution and richer skill manifests remain incomplete.
 - Codex CLI: `codex-cli` can drive responses and `codex.exec` is available as a high-risk approval-gated tool. It is not yet a branch-isolated autonomous repair loop.
@@ -43,7 +44,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 
 ## Not Done Yet
 
-- Native OpenAI function/tool calling and native streaming deltas.
+- Native OpenAI streaming deltas and broader provider integration tests for OpenRouter/Anthropic/Ollama-style adapters.
 - Full durable multi-step planner/executor/reviewer loop with resumable goals, retries, and review gates.
 - Production authentication, authorization, and user/session isolation for the UI/API.
 - Production webhook signature verification and secret rotation for external channel endpoints.
@@ -63,6 +64,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - `complete.mv2` is a run artifact under `.nest/runs/{run_id}/`, not a permanent memory layer.
 - SQLite is control-plane state only. It is not the retrieval memory substrate.
 - Mock-provider tests are the default fast validation path; Memvid integration remains behind `RUN_MEMVID_INTEGRATION=1`.
+- Provider fallback only runs for `ProviderError(retryable=True)` failures; non-retryable errors fail fast and preserve the original provider error.
 
 ## Validation Commands
 

--- a/src/nested_memvid_agent/config.py
+++ b/src/nested_memvid_agent/config.py
@@ -14,6 +14,10 @@ class AgentConfig:
     model: str = "mock"
     base_url: str | None = None
     api_key_env: str | None = None
+    fallback_provider: str | None = None
+    fallback_model: str | None = None
+    fallback_base_url: str | None = None
+    fallback_api_key_env: str | None = None
     timeout_seconds: int = 60
     max_retries: int = 2
     temperature: float = 0.2
@@ -53,6 +57,10 @@ class AgentConfig:
             model=os.getenv("NEST_AGENT_MODEL", "mock"),
             base_url=_env_str_or_none("NEST_AGENT_BASE_URL"),
             api_key_env=_env_str_or_none("NEST_AGENT_API_KEY_ENV"),
+            fallback_provider=_env_str_or_none("NEST_AGENT_FALLBACK_PROVIDER"),
+            fallback_model=_env_str_or_none("NEST_AGENT_FALLBACK_MODEL"),
+            fallback_base_url=_env_str_or_none("NEST_AGENT_FALLBACK_BASE_URL"),
+            fallback_api_key_env=_env_str_or_none("NEST_AGENT_FALLBACK_API_KEY_ENV"),
             timeout_seconds=_env_int("NEST_AGENT_TIMEOUT_SECONDS", 60),
             max_retries=_env_int("NEST_AGENT_MAX_RETRIES", 2),
             temperature=_env_float("NEST_AGENT_TEMPERATURE", 0.2),

--- a/src/nested_memvid_agent/llm/base.py
+++ b/src/nested_memvid_agent/llm/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 from ..runtime_models import ChatMessage, LLMOptions, LLMResponse, LLMStreamEvent, ToolSpec
 
@@ -13,7 +14,33 @@ class ProviderError(RuntimeError):
         self.retryable = retryable
 
 
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    name: str
+    supports_native_tools: bool = False
+    supports_streaming: bool = False
+    supports_json_mode: bool = False
+    supports_system_messages: bool = True
+    max_context_tokens: int | None = None
+    token_usage_available: bool = False
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "supports_native_tools": self.supports_native_tools,
+            "supports_streaming": self.supports_streaming,
+            "supports_json_mode": self.supports_json_mode,
+            "supports_system_messages": self.supports_system_messages,
+            "max_context_tokens": self.max_context_tokens,
+            "token_usage_available": self.token_usage_available,
+        }
+
+
 class LLMProvider(ABC):
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(name=type(self).__name__)
+
     @abstractmethod
     def generate(
         self,
@@ -35,3 +62,59 @@ class LLMProvider(ABC):
         for tool_call in response.tool_calls:
             yield LLMStreamEvent(type="tool_call", tool_call=tool_call)
         yield LLMStreamEvent(type="message_complete", response=response)
+
+
+class FallbackLLMProvider(LLMProvider):
+    """Try a secondary provider only for retryable primary provider failures."""
+
+    def __init__(self, primary: LLMProvider, secondary: LLMProvider) -> None:
+        self.primary = primary
+        self.secondary = secondary
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        primary = self.primary.capabilities
+        secondary = self.secondary.capabilities
+        return ProviderCapabilities(
+            name=f"fallback:{primary.name}->{secondary.name}",
+            supports_native_tools=primary.supports_native_tools and secondary.supports_native_tools,
+            supports_streaming=primary.supports_streaming and secondary.supports_streaming,
+            supports_json_mode=primary.supports_json_mode and secondary.supports_json_mode,
+            supports_system_messages=primary.supports_system_messages and secondary.supports_system_messages,
+            max_context_tokens=min(
+                token for token in (primary.max_context_tokens, secondary.max_context_tokens) if token is not None
+            )
+            if primary.max_context_tokens is not None or secondary.max_context_tokens is not None
+            else None,
+            token_usage_available=primary.token_usage_available and secondary.token_usage_available,
+        )
+
+    def generate(
+        self,
+        messages: list[ChatMessage],
+        tools: list[ToolSpec],
+        options: LLMOptions | None = None,
+    ) -> LLMResponse:
+        try:
+            return self.primary.generate(messages, tools, options)
+        except ProviderError as exc:
+            if not exc.retryable:
+                raise
+            response = self.secondary.generate(messages, tools, options)
+            raw = response.raw if isinstance(response.raw, dict) else {"secondary_raw": response.raw}
+            raw = {
+                **raw,
+                "provider_fallback": {
+                    "from": self.primary.capabilities.name,
+                    "to": self.secondary.capabilities.name,
+                    "from_error_code": exc.code,
+                    "from_error": str(exc),
+                },
+            }
+            return LLMResponse(
+                content=response.content,
+                tool_calls=response.tool_calls,
+                raw=raw,
+                usage=response.usage,
+                finish_reason=response.finish_reason,
+            )

--- a/src/nested_memvid_agent/llm/codex_cli_provider.py
+++ b/src/nested_memvid_agent/llm/codex_cli_provider.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ..runtime_models import ChatMessage, LLMOptions, LLMResponse, ToolSpec
-from .base import LLMProvider, ProviderError
+from .base import LLMProvider, ProviderCapabilities, ProviderError
 from .parser import parse_agent_response
 
 
@@ -33,6 +33,17 @@ class CodexCLIProvider(LLMProvider):
         self.profile = profile
         self.skip_git_repo_check = skip_git_repo_check
         self.ephemeral = ephemeral
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            name="codex-cli",
+            supports_native_tools=False,
+            supports_streaming=False,
+            supports_json_mode=True,
+            supports_system_messages=True,
+            token_usage_available=False,
+        )
 
     def generate(
         self,

--- a/src/nested_memvid_agent/llm/factory.py
+++ b/src/nested_memvid_agent/llm/factory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ..config import AgentConfig
-from .base import LLMProvider
+from .base import FallbackLLMProvider, LLMProvider
 from .codex_cli_provider import CodexCLIProvider
 from .mock import MockLLMProvider
 from .openai_compatible_provider import OpenAICompatibleProvider
@@ -9,34 +9,55 @@ from .openai_provider import OpenAIResponsesProvider
 
 
 def build_llm_provider(config: AgentConfig) -> LLMProvider:
-    if config.provider == "mock":
+    provider = _build_single_provider(config, provider=config.provider, model=config.model, base_url=config.base_url, api_key_env=config.api_key_env)
+    if config.fallback_provider:
+        fallback = _build_single_provider(
+            config,
+            provider=config.fallback_provider,
+            model=config.fallback_model or config.model,
+            base_url=config.fallback_base_url,
+            api_key_env=config.fallback_api_key_env or config.api_key_env,
+        )
+        return FallbackLLMProvider(provider, fallback)
+    return provider
+
+
+def _build_single_provider(
+    config: AgentConfig,
+    *,
+    provider: str,
+    model: str,
+    base_url: str | None,
+    api_key_env: str | None,
+) -> LLMProvider:
+    if provider == "mock":
         return MockLLMProvider()
-    if config.provider == "openai":
+    if provider == "openai":
         return OpenAIResponsesProvider(
-            model=config.model,
-            api_key_env=config.api_key_env,
+            model=model,
+            api_key_env=api_key_env,
             timeout_seconds=config.timeout_seconds,
             max_retries=config.max_retries,
             temperature=config.temperature,
         )
-    if config.provider == "openai-compatible":
-        if not config.base_url:
+    if provider == "openai-compatible":
+        if not base_url:
             raise ValueError("openai-compatible provider requires base_url")
         return OpenAICompatibleProvider(
-            model=config.model,
-            base_url=config.base_url,
-            api_key_env=config.api_key_env,
+            model=model,
+            base_url=base_url,
+            api_key_env=api_key_env,
             timeout_seconds=config.timeout_seconds,
             max_retries=config.max_retries,
             temperature=config.temperature,
         )
-    if config.provider == "codex-cli":
+    if provider == "codex-cli":
         return CodexCLIProvider(
-            model=config.model,
+            model=model,
             workspace=config.workspace,
             sandbox=config.codex_sandbox,
             profile=config.codex_profile,
             skip_git_repo_check=config.codex_skip_git_repo_check,
             ephemeral=config.codex_ephemeral,
         )
-    raise ValueError(f"Unsupported provider: {config.provider}")
+    raise ValueError(f"Unsupported provider: {provider}")

--- a/src/nested_memvid_agent/llm/mock.py
+++ b/src/nested_memvid_agent/llm/mock.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from ..runtime_models import ChatMessage, LLMOptions, LLMResponse, ToolCall, ToolSpec
-from .base import LLMProvider
+from .base import LLMProvider, ProviderCapabilities
 
 
 class MockLLMProvider(LLMProvider):
@@ -16,6 +16,17 @@ class MockLLMProvider(LLMProvider):
 
     def __init__(self, canned: Iterable[LLMResponse] | None = None) -> None:
         self._responses = list(canned or [])
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            name="mock",
+            supports_native_tools=True,
+            supports_streaming=True,
+            supports_json_mode=True,
+            supports_system_messages=True,
+            token_usage_available=False,
+        )
 
     def generate(
         self,

--- a/src/nested_memvid_agent/llm/openai_compatible_provider.py
+++ b/src/nested_memvid_agent/llm/openai_compatible_provider.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from typing import Any
 
 from ..runtime_models import ChatMessage, LLMOptions, LLMResponse, ToolSpec
-from .base import LLMProvider, ProviderError
+from .base import LLMProvider, ProviderCapabilities, ProviderError
 from .parser import parse_agent_response
 
 
@@ -29,6 +29,17 @@ class OpenAICompatibleProvider(LLMProvider):
         self.timeout_seconds = timeout_seconds
         self.max_retries = max_retries
         self.temperature = temperature
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            name="openai-compatible",
+            supports_native_tools=False,
+            supports_streaming=False,
+            supports_json_mode=True,
+            supports_system_messages=True,
+            token_usage_available=False,
+        )
 
     def generate(
         self,

--- a/src/nested_memvid_agent/llm/openai_provider.py
+++ b/src/nested_memvid_agent/llm/openai_provider.py
@@ -6,7 +6,7 @@ from importlib import import_module
 from typing import Any
 
 from ..runtime_models import ChatMessage, LLMOptions, LLMResponse, ToolCall, ToolSpec
-from .base import LLMProvider, ProviderError
+from .base import LLMProvider, ProviderCapabilities, ProviderError
 from .parser import parse_agent_response
 
 
@@ -33,6 +33,17 @@ class OpenAIResponsesProvider(LLMProvider):
         self.timeout_seconds = timeout_seconds
         self.max_retries = max_retries
         self.temperature = temperature
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            name="openai",
+            supports_native_tools=True,
+            supports_streaming=False,
+            supports_json_mode=True,
+            supports_system_messages=True,
+            token_usage_available=True,
+        )
 
     def generate(
         self,

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -6,10 +6,89 @@ from typing import Any
 import pytest
 
 from nested_memvid_agent.config import AgentConfig
+from nested_memvid_agent.llm.base import (
+    FallbackLLMProvider,
+    LLMProvider,
+    ProviderCapabilities,
+    ProviderError,
+)
 from nested_memvid_agent.llm.factory import build_llm_provider
 from nested_memvid_agent.llm.openai_compatible_provider import OpenAICompatibleProvider
 from nested_memvid_agent.llm.openai_provider import OpenAIResponsesProvider
-from nested_memvid_agent.runtime_models import ChatMessage, LLMOptions, ToolSpec
+from nested_memvid_agent.runtime_models import ChatMessage, LLMOptions, LLMResponse, ToolSpec
+
+
+class RecordingProvider(LLMProvider):
+    def __init__(self, response: LLMResponse | None = None, error: ProviderError | None = None) -> None:
+        self.response = response or LLMResponse(content="ok")
+        self.error = error
+        self.calls = 0
+
+    def generate(
+        self,
+        messages: list[ChatMessage],
+        tools: list[ToolSpec],
+        options: LLMOptions | None = None,
+    ) -> LLMResponse:
+        del messages, tools, options
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def test_provider_capabilities_have_serializable_metadata() -> None:
+    caps = ProviderCapabilities(
+        name="test-provider",
+        supports_native_tools=True,
+        supports_streaming=True,
+        supports_json_mode=False,
+        supports_system_messages=True,
+        max_context_tokens=8192,
+        token_usage_available=True,
+    )
+
+    assert caps.to_payload() == {
+        "name": "test-provider",
+        "supports_native_tools": True,
+        "supports_streaming": True,
+        "supports_json_mode": False,
+        "supports_system_messages": True,
+        "max_context_tokens": 8192,
+        "token_usage_available": True,
+    }
+
+
+def test_fallback_provider_uses_secondary_for_retryable_primary_error() -> None:
+    primary = RecordingProvider(error=ProviderError("temporary", code="rate_limit", retryable=True))
+    secondary = RecordingProvider(response=LLMResponse(content="secondary ok"))
+    provider = FallbackLLMProvider(primary, secondary)
+
+    response = provider.generate([ChatMessage(role="user", content="hello")], tools=[])
+
+    assert response.content == "secondary ok"
+    assert primary.calls == 1
+    assert secondary.calls == 1
+    assert response.raw["provider_fallback"]["from_error_code"] == "rate_limit"
+
+
+def test_fallback_provider_does_not_fallback_for_non_retryable_error() -> None:
+    primary = RecordingProvider(error=ProviderError("bad key", code="auth_error", retryable=False))
+    secondary = RecordingProvider(response=LLMResponse(content="should not run"))
+    provider = FallbackLLMProvider(primary, secondary)
+
+    with pytest.raises(ProviderError):
+        provider.generate([ChatMessage(role="user", content="hello")], tools=[])
+
+    assert primary.calls == 1
+    assert secondary.calls == 0
+
+
+def test_factory_wraps_configured_fallback_provider() -> None:
+    provider = build_llm_provider(AgentConfig(provider="mock", fallback_provider="mock"))
+
+    assert isinstance(provider, FallbackLLMProvider)
+    assert provider.capabilities.name == "fallback:mock->mock"
 
 
 def test_factory_builds_openai_compatible_provider() -> None:


### PR DESCRIPTION
## Summary
- add provider capability metadata and payload serialization
- expose capabilities on mock, OpenAI, OpenAI-compatible, and Codex CLI providers
- add retryable-error fallback provider wrapper and config/env wiring

## Validation
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"