### PR TITLE
feat: add MCP vetting metadata

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -20,10 +20,11 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Safe self-repair now has branch-isolated repair primitives: `repair.prepare`, `repair.status`, `repair.apply_patch`, `repair.validate`, and `repair.rollback`.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
-- SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `4`.
+- SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `5`.
 - Paper-guided nested learning kernel with context-flow metadata, optimizer traces, conservative continuum-memory routing, and a `memory.learn` tool/API path.
 - Run-scoped `complete.mv2` task capsules, preview-only capsule summaries, dry-run consolidation decisions, and approval-gated capsule apply.
 - MCP server records now track health metadata, tool counts, capabilities, last sync/seen/call/error timestamps, session state, failure counts, and latency.
+- MCP server records now persist vetting metadata: transport/network exposure, secret-env requirements, per-tool risk/approval classification, risk reasons, and recommended trust posture.
 - MCP stdio servers now have a managed lazy session lifecycle with connect/disconnect/restart/health API routes, bounded operation timeouts, config-change teardown, and approval-by-default tool risk normalization.
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
@@ -65,6 +66,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - SQLite is control-plane state only. It is not the retrieval memory substrate.
 - Mock-provider tests are the default fast validation path; Memvid integration remains behind `RUN_MEMVID_INTEGRATION=1`.
 - Provider fallback only runs for `ProviderError(retryable=True)` failures; non-retryable errors fail fast and preserve the original provider error.
+- MCP tools remain approval-by-default unless a server is explicitly configured to trust its manifest; dangerous tool names/descriptions such as file writes, deletes, shell execution, patching, committing, or secrets are promoted to high risk during vetting.
 
 ## Validation Commands
 

--- a/src/nested_memvid_agent/mcp_manager.py
+++ b/src/nested_memvid_agent/mcp_manager.py
@@ -95,6 +95,7 @@ class MCPManager:
             row["last_synced_at"] = _now()
             row["tool_count"] = len(tools)
             row["capabilities"] = _capabilities_from_tools(tools)
+            row["vetting"] = _vetting_for_server(_server_from_state(row), tools)
             row["failure_count"] = 0
             row["last_latency_ms"] = _elapsed_ms(started)
             return {"ok": True, "message": f"Connected and discovered {len(tools)} tools.", "server": self.state.upsert_mcp_server(row)}
@@ -139,6 +140,7 @@ class MCPManager:
             row["last_seen_at"] = _now()
             row["tool_count"] = len(tools)
             row["capabilities"] = _capabilities_from_tools(tools)
+            row["vetting"] = _vetting_for_server(_server_from_state(row), tools)
             row["failure_count"] = 0
             row["last_latency_ms"] = _elapsed_ms(started)
             return {"ok": True, "message": "Live MCP session is healthy.", "server": self.state.upsert_mcp_server(row)}
@@ -161,6 +163,7 @@ class MCPManager:
             server["last_seen_at"] = _now()
             server["tool_count"] = len(tools)
             server["capabilities"] = _capabilities_from_tools(tools)
+            server["vetting"] = _vetting_for_server(_server_from_state(server), tools)
             server["failure_count"] = 0
             server["last_latency_ms"] = _elapsed_ms(started)
         except Exception as exc:  # noqa: BLE001 - stored for UI visibility
@@ -456,6 +459,8 @@ def _normalize_server(payload: dict[str, Any]) -> MCPServerConfig:
 
 
 def _server_to_dict(server: MCPServerConfig) -> dict[str, Any]:
+    vetted_tools = [_normalize_tool(server, tool) for tool in server.tools]
+    vetting = _vetting_for_server(server, vetted_tools)
     return {
         "id": server.id,
         "name": server.name,
@@ -465,12 +470,14 @@ def _server_to_dict(server: MCPServerConfig) -> dict[str, Any]:
         "env": server.env or {},
         "url": server.url,
         "enabled": server.enabled,
-        "tools": list(server.tools),
+        "tools": vetted_tools,
         "status": "configured",
         "error": None,
         "risk_policy": server.risk_policy,
         "session_state": "disconnected",
         "failure_count": 0,
+        "capabilities": _capabilities_from_tools(vetted_tools),
+        "vetting": vetting,
     }
 
 
@@ -540,13 +547,89 @@ def _normalize_sdk_tool(server: MCPServerConfig, tool: Any) -> dict[str, Any]:
 
 
 def _risk_fields(server: MCPServerConfig, tool: dict[str, Any]) -> tuple[RiskLevel, bool]:
+    inferred = _infer_tool_risk(tool)
     if server.risk_policy == MCP_TRUST_MANIFEST_POLICY or bool(tool.get("trusted") or tool.get("allow_autonomous")):
-        risk = _risk_level(tool.get("risk", "low"))
+        risk = _max_risk(_risk_level(tool.get("risk", "low")), inferred)
         return risk, bool(tool.get("requires_approval", risk in {"medium", "high"}))
-    risk = _risk_level(tool.get("risk", "medium"))
+    risk = _max_risk(_risk_level(tool.get("risk", "medium")), inferred)
     if risk == "low":
         risk = "medium"
     return risk, True
+
+
+def _infer_tool_risk(tool: dict[str, Any]) -> RiskLevel:
+    name = str(tool.get("remote_name") or tool.get("name") or "").lower()
+    description = str(tool.get("description") or "").lower()
+    haystack = f"{name} {description}"
+    high_markers = (
+        "write",
+        "delete",
+        "remove",
+        "patch",
+        "apply",
+        "commit",
+        "push",
+        "shell",
+        "exec",
+        "command",
+        "filesystem",
+        "file",
+        "secret",
+        "token",
+        "credential",
+    )
+    if any(marker in haystack for marker in high_markers):
+        return "high"
+    network_markers = ("http", "request", "fetch", "post", "send", "email", "message")
+    if any(marker in haystack for marker in network_markers):
+        return "medium"
+    return "low"
+
+
+def _max_risk(left: RiskLevel, right: RiskLevel) -> RiskLevel:
+    order = {"low": 0, "medium": 1, "high": 2}
+    return left if order[left] >= order[right] else right
+
+
+def _vetting_for_server(server: MCPServerConfig, tools: list[dict[str, Any]]) -> dict[str, Any]:
+    secrets = sorted(key for key in (server.env or {}) if _looks_secret(key))
+    network_access = server.transport in {"sse", "streamable_http"} or bool(server.url)
+    risk_reasons: list[str] = []
+    if network_access:
+        risk_reasons.append("network")
+    if secrets:
+        risk_reasons.append("secrets")
+    if server.transport not in {"stdio", "sse", "streamable_http"}:
+        risk_reasons.append("unknown_transport")
+    if any(str(tool.get("risk")) == "high" for tool in tools):
+        risk_reasons.append("high_risk_tools")
+    if server.risk_policy != MCP_TRUST_MANIFEST_POLICY:
+        risk_reasons.append("approval_by_default")
+    recommended_trust = "approval_required" if risk_reasons else "low_risk"
+    return {
+        "server_id": server.id,
+        "transport": server.transport,
+        "network_access": network_access,
+        "secrets_required": secrets,
+        "risk_policy": server.risk_policy,
+        "recommended_trust": recommended_trust,
+        "risk_reasons": sorted(set(risk_reasons)),
+        "tools": [
+            {
+                "name": str(tool.get("remote_name") or tool.get("name")),
+                "registered_name": str(tool.get("name")),
+                "risk": str(tool.get("risk", "medium")),
+                "requires_approval": bool(tool.get("requires_approval", True)),
+                "capabilities": list(tool.get("capabilities", [])),
+            }
+            for tool in tools
+        ],
+    }
+
+
+def _looks_secret(name: str) -> bool:
+    upper = name.upper()
+    return any(marker in upper for marker in ("TOKEN", "KEY", "SECRET", "PASSWORD", "CREDENTIAL"))
 
 
 def _risk_level(value: object) -> RiskLevel:

--- a/src/nested_memvid_agent/state_store.py
+++ b/src/nested_memvid_agent/state_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from threading import RLock
 from typing import Any
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 
 def utc_now() -> str:
@@ -310,6 +310,7 @@ class AgentStateStore:
             "last_error_at": server.get("last_error_at"),
             "failure_count": int(server.get("failure_count", 0)),
             "last_latency_ms": server.get("last_latency_ms"),
+            "vetting_json": json.dumps(server.get("vetting", {})),
             "updated_at": now,
         }
         with self._connect() as conn:
@@ -319,8 +320,8 @@ class AgentStateStore:
                     id, name, transport, command, args_json, env_json, url, enabled,
                     tools_json, status, error, last_synced_at, last_seen_at, tool_count,
                     capabilities_json, risk_policy, secret_env_json, session_state, last_call_at,
-                    last_error_at, failure_count, last_latency_ms, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    last_error_at, failure_count, last_latency_ms, vetting_json, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
                     transport = excluded.transport,
@@ -343,6 +344,7 @@ class AgentStateStore:
                     last_error_at = excluded.last_error_at,
                     failure_count = excluded.failure_count,
                     last_latency_ms = excluded.last_latency_ms,
+                    vetting_json = excluded.vetting_json,
                     updated_at = excluded.updated_at
                 """,
                 (server_id, *payload.values()),
@@ -568,6 +570,9 @@ class AgentStateStore:
             if current < 4:
                 _apply_schema_v4(conn)
                 current = 4
+            if current < 5:
+                _apply_schema_v5(conn)
+                current = 5
             if current < SCHEMA_VERSION:
                 raise RuntimeError(f"Unsupported schema migration target: {current} -> {SCHEMA_VERSION}")
             if current == SCHEMA_VERSION:
@@ -749,6 +754,12 @@ def _apply_schema_v4(conn: sqlite3.Connection) -> None:
             conn.execute(f"ALTER TABLE task_nodes ADD COLUMN {name} {definition}")
 
 
+def _apply_schema_v5(conn: sqlite3.Connection) -> None:
+    existing = _columns(conn, "mcp_servers")
+    if "vetting_json" not in existing:
+        conn.execute("ALTER TABLE mcp_servers ADD COLUMN vetting_json TEXT NOT NULL DEFAULT '{}'")
+
+
 def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
 
@@ -825,6 +836,7 @@ def _mcp_from_row(row: sqlite3.Row) -> dict[str, Any]:
         "last_error_at": _row_get(row, "last_error_at"),
         "failure_count": int(str(_row_get(row, "failure_count", 0) or 0)),
         "last_latency_ms": _row_get(row, "last_latency_ms"),
+        "vetting": json.loads(str(_row_get(row, "vetting_json", "{}") or "{}")),
         "updated_at": str(row["updated_at"]),
     }
 

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -167,7 +167,7 @@ def test_state_store_initializes_version_and_indexes(tmp_path: Path) -> None:
     db_path = tmp_path / "state.db"
     state = AgentStateStore(db_path)
 
-    assert state.schema_version() == 4
+    assert state.schema_version() == 5
     with sqlite3.connect(db_path) as conn:
         run_indexes = {row[1] for row in conn.execute("PRAGMA index_list('runs')").fetchall()}
         approval_indexes = {row[1] for row in conn.execute("PRAGMA index_list('approval_requests')").fetchall()}
@@ -188,6 +188,7 @@ def test_state_store_initializes_version_and_indexes(tmp_path: Path) -> None:
         "last_error_at",
         "failure_count",
         "last_latency_ms",
+        "vetting_json",
     } <= mcp_columns
 
 
@@ -220,6 +221,36 @@ def test_mcp_static_tools_enter_unified_registry(tmp_path: Path) -> None:
     assert specs["mcp.demo.echo"].source == "mcp"
     assert specs["mcp.demo.echo"].risk == "medium"
     assert specs["mcp.demo.echo"].requires_approval is True
+
+
+def test_mcp_vetting_metadata_identifies_secrets_network_and_high_risk_tools(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    manager = MCPManager(state)
+
+    row = manager.add_server(
+        {
+            "id": "github",
+            "transport": "sse",
+            "url": "https://mcp.example.test/sse",
+            "env": {"GITHUB_TOKEN": "dummy-token", "LOG_LEVEL": "debug"},
+            "tools": [
+                {"name": "list_issues", "description": "List issues", "risk": "low"},
+                {"name": "write_file", "description": "Write a file", "risk": "low"},
+            ],
+        }
+    )
+
+    vetting = row["vetting"]
+    assert vetting["transport"] == "sse"
+    assert vetting["network_access"] is True
+    assert vetting["secrets_required"] == ["GITHUB_TOKEN"]
+    assert vetting["recommended_trust"] == "approval_required"
+    assert "network" in vetting["risk_reasons"]
+    high_risk = {tool["name"]: tool for tool in vetting["tools"]}
+    assert high_risk["write_file"]["risk"] == "high"
+    assert high_risk["write_file"]["requires_approval"] is True
+    assert row["tools"][1]["risk"] == "high"
+    assert row["tools"][1]["requires_approval"] is True
 
 
 def test_mcp_static_server_test_updates_health(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add persisted MCP vetting metadata for transport, network exposure, secret env requirements, risk reasons, and trust posture
- promote dangerous MCP tool names/descriptions to high risk during approval-by-default vetting
- bump state schema to v5 and add tests/docs for MCP vetting

## Validation
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"