### PR TITLE
feat: validate skill manifests

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -18,6 +18,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Self-diagnosis primitives can classify common provider/tool/test/import/permission/MCP/sandbox failures and recall similar procedural/episodic failure lessons before retry.
 - Safe self-repair now has branch-isolated repair primitives: `repair.prepare`, `repair.status`, `repair.apply_patch`, `repair.validate`, and `repair.rollback`.
+- Skills now have a first manifest validation gate plus persisted validation/provenance metadata for discovered instruction capsules.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `5`.
@@ -34,7 +35,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 
 - Streaming/provider parity: the runtime, CLI, and web run event bus accept stream events, and provider capability metadata exists. Native streaming deltas and richer per-provider context/JSON-mode details still need hardening.
 - MCP: stdio live sessions are hardened and covered by a flag-gated integration test. SSE and streamable HTTP use the same manager path but still need real transport fixtures and production soak testing.
-- Skills: filesystem discovery and skill tool adapters exist. Sandboxed skill execution and richer skill manifests remain incomplete.
+- Skills: filesystem discovery, manifest validation, provenance metadata, and skill tool adapters exist. Sandboxed skill execution remains incomplete.
 - Codex CLI: `codex-cli` can drive responses and `codex.exec` is available as a high-risk approval-gated tool. It is not yet a branch-isolated autonomous repair loop.
 - Consolidation: capsule extraction and Nested Learning decisions exist, but auto-consolidation remains disabled by default and validation loops are still basic.
 - Self-diagnosis: first-pass classification and memory recall tools exist. A full executor retry gate that forces changed strategy before every retry is still incomplete.
@@ -67,6 +68,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Mock-provider tests are the default fast validation path; Memvid integration remains behind `RUN_MEMVID_INTEGRATION=1`.
 - Provider fallback only runs for `ProviderError(retryable=True)` failures; non-retryable errors fail fast and preserve the original provider error.
 - MCP tools remain approval-by-default unless a server is explicitly configured to trust its manifest; dangerous tool names/descriptions such as file writes, deletes, shell execution, patching, committing, or secrets are promoted to high risk during vetting.
+- Invalid skill manifests are rejected during discovery; accepted skill manifests record validation status plus manifest/SKILL.md content hashes for provenance.
 
 ## Validation Commands
 

--- a/src/nested_memvid_agent/skill_manager.py
+++ b/src/nested_memvid_agent/skill_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,23 +29,38 @@ class SkillManager:
     def __init__(self, root: Path, state: AgentStateStore) -> None:
         self.root = root
         self.state = state
+        self.validation_errors: list[dict[str, Any]] = []
         self.root.mkdir(parents=True, exist_ok=True)
 
     def discover(self) -> list[dict[str, Any]]:
         found: list[dict[str, Any]] = []
+        self.validation_errors = []
         for skill_dir in sorted(path for path in self.root.iterdir() if path.is_dir()):
             manifest_path = skill_dir / "skill.json"
             instructions_path = skill_dir / "SKILL.md"
             if not manifest_path.exists() or not instructions_path.exists():
                 continue
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            try:
+                manifest_text = manifest_path.read_text(encoding="utf-8")
+                instructions = instructions_path.read_text(encoding="utf-8")
+                manifest = json.loads(manifest_text)
+            except (OSError, json.JSONDecodeError) as exc:
+                self.validation_errors.append({"path": str(skill_dir), "errors": [f"manifest_read_failed:{type(exc).__name__}"]})
+                continue
+            validation = validate_skill_manifest(manifest)
+            if validation["errors"]:
+                self.validation_errors.append({"path": str(skill_dir), **validation})
+                continue
+            manifest = dict(manifest)
+            manifest["validation"] = validation
+            manifest["provenance"] = _skill_provenance(skill_dir, manifest_text, instructions)
             capsule = SkillCapsule(
                 id=str(manifest.get("id", skill_dir.name)),
                 name=str(manifest.get("name", skill_dir.name)),
                 description=str(manifest.get("description", "")),
                 path=skill_dir,
                 manifest=manifest,
-                instructions=instructions_path.read_text(encoding="utf-8"),
+                instructions=instructions,
                 enabled=bool(manifest.get("enabled", True)),
             )
             found.append(self.state.upsert_skill(_capsule_to_state(capsule)))
@@ -121,6 +137,44 @@ class SkillToolAdapter(AgentTool):
             content=content,
             data={"skill_id": self.capsule.id, "memory_record_id": record_id},
         )
+
+
+def validate_skill_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not str(manifest.get("id", "")).strip():
+        errors.append("missing_id")
+    if not str(manifest.get("description", "")).strip():
+        errors.append("missing_description")
+    risk = str(manifest.get("risk", "medium")).strip().lower()
+    if risk not in {"low", "medium", "high"}:
+        errors.append("invalid_risk")
+    runtime = manifest.get("runtime", {"type": "instruction"})
+    if not isinstance(runtime, dict):
+        errors.append("invalid_runtime")
+    elif str(runtime.get("type", "instruction")) not in {"instruction", "python", "shell", "container"}:
+        errors.append("unsupported_runtime")
+    for field in ("capabilities", "permissions", "tests"):
+        if field in manifest and not isinstance(manifest[field], list):
+            errors.append(f"invalid_{field}")
+    for field in ("parameters", "inputs", "outputs"):
+        if field in manifest and not isinstance(manifest[field], dict):
+            errors.append(f"invalid_{field}")
+    if "version" not in manifest:
+        warnings.append("missing_version")
+    if "permissions" not in manifest:
+        warnings.append("missing_permissions")
+    if "runtime" not in manifest:
+        warnings.append("default_instruction_runtime")
+    return {"ok": not errors, "errors": errors, "warnings": warnings}
+
+
+def _skill_provenance(skill_dir: Path, manifest_text: str, instructions: str) -> dict[str, Any]:
+    return {
+        "path": str(skill_dir),
+        "manifest_sha256": hashlib.sha256(manifest_text.encode("utf-8")).hexdigest(),
+        "instructions_sha256": hashlib.sha256(instructions.encode("utf-8")).hexdigest(),
+    }
 
 
 def _capsule_to_state(capsule: SkillCapsule) -> dict[str, Any]:

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -17,7 +17,7 @@ from nested_memvid_agent.orchestrator import build_memory_system
 from nested_memvid_agent.run_manager import RunManager
 from nested_memvid_agent.runtime_models import AgentTurnResult
 from nested_memvid_agent.server import create_app
-from nested_memvid_agent.skill_manager import SkillManager
+from nested_memvid_agent.skill_manager import SkillManager, validate_skill_manifest
 from nested_memvid_agent.state_store import AgentStateStore
 from nested_memvid_agent.tools.builtin import build_default_tools
 
@@ -474,6 +474,59 @@ def test_skill_discovery_exposes_nested_learning_skill(tmp_path: Path) -> None:
     assert adapters[0].spec.source == "skill"
     disabled = manager.set_enabled("review", False)
     assert disabled["enabled"] is False
+
+
+def test_skill_manifest_validation_records_provenance_and_rejects_invalid_skill(tmp_path: Path) -> None:
+    valid_dir = tmp_path / "skills" / "safe"
+    valid_dir.mkdir(parents=True)
+    (valid_dir / "skill.json").write_text(
+        json.dumps(
+            {
+                "id": "safe",
+                "name": "Safe Skill",
+                "description": "Safe instruction-only skill.",
+                "version": "1.0.0",
+                "risk": "low",
+                "capabilities": ["skill"],
+                "permissions": [],
+                "runtime": {"type": "instruction"},
+                "tests": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (valid_dir / "SKILL.md").write_text("Do safe things only.", encoding="utf-8")
+    invalid_dir = tmp_path / "skills" / "invalid"
+    invalid_dir.mkdir()
+    (invalid_dir / "skill.json").write_text(json.dumps({"id": "invalid", "risk": "spicy"}), encoding="utf-8")
+    (invalid_dir / "SKILL.md").write_text("No description.", encoding="utf-8")
+
+    state = AgentStateStore(tmp_path / "state.db")
+    manager = SkillManager(tmp_path / "skills", state)
+    discovered = manager.discover()
+
+    assert [skill["id"] for skill in discovered] == ["safe"]
+    manifest = discovered[0]["manifest"]
+    assert manifest["validation"]["ok"] is True
+    assert len(manifest["provenance"]["manifest_sha256"]) == 64
+    assert manager.validation_errors[0]["errors"] == ["missing_description", "invalid_risk"]
+    assert manager.tool_adapters()[0].spec.risk == "low"
+
+
+def test_validate_skill_manifest_rejects_bad_shapes() -> None:
+    result = validate_skill_manifest(
+        {
+            "id": "bad",
+            "description": "Bad shape",
+            "risk": "medium",
+            "capabilities": "skill",
+            "permissions": {},
+            "runtime": {"type": "spaceship"},
+        }
+    )
+
+    assert result["ok"] is False
+    assert {"invalid_capabilities", "invalid_permissions", "unsupported_runtime"} <= set(result["errors"])
 
 
 def test_cancelled_run_cannot_be_overwritten_completed_after_agent_returns(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add first-pass skill manifest validation with structured errors/warnings
- reject invalid skill manifests during discovery and expose validation errors
- persist validation/provenance metadata with manifest and SKILL.md content hashes

## Validation
- python -m compileall -q src tests
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"