### PR TITLE
feat: expose memory promotion gates

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -23,6 +23,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
 - SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `5`.
 - Paper-guided nested learning kernel with context-flow metadata, optimizer traces, conservative continuum-memory routing, and a `memory.learn` tool/API path.
+- Memory learning decisions now expose explicit promotion gate metadata so rejected/accepted decisions can explain target layer, observed evidence, repeat-count thresholds, validation thresholds, and explicit-instruction requirements.
 - Run-scoped `complete.mv2` task capsules, preview-only capsule summaries, dry-run consolidation decisions, and approval-gated capsule apply.
 - MCP server records now track health metadata, tool counts, capabilities, last sync/seen/call/error timestamps, session state, failure counts, and latency.
 - MCP server records now persist vetting metadata: transport/network exposure, secret-env requirements, per-tool risk/approval classification, risk reasons, and recommended trust posture.
@@ -69,6 +70,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Provider fallback only runs for `ProviderError(retryable=True)` failures; non-retryable errors fail fast and preserve the original provider error.
 - MCP tools remain approval-by-default unless a server is explicitly configured to trust its manifest; dangerous tool names/descriptions such as file writes, deletes, shell execution, patching, committing, or secrets are promoted to high risk during vetting.
 - Invalid skill manifests are rejected during discovery; accepted skill manifests record validation status plus manifest/SKILL.md content hashes for provenance.
+- Memory promotion decisions must carry auditable gate metadata; one-off procedural successes and ordinary events can explain why they were not promoted into procedural/policy memory.
 
 ## Validation Commands
 

--- a/scripts/run_golden_evals.py
+++ b/scripts/run_golden_evals.py
@@ -17,7 +17,7 @@ from nested_memvid_agent.config import AgentConfig
 from nested_memvid_agent.context_packer import ContextPacker, ContextPackRequest
 from nested_memvid_agent.layers import DEFAULT_LAYER_SPECS
 from nested_memvid_agent.models import MemoryKind, MemoryLayer, MemoryRecord, RetrievalQuery
-from nested_memvid_agent.nested_learning import NestedLearningKernel
+from nested_memvid_agent.nested_learning import LearningSignal, NestedLearningKernel
 from nested_memvid_agent.runtime_models import ToolCall
 from nested_memvid_agent.task_capsule import summarize_run_capsule, write_run_capsule
 from nested_memvid_agent.tools.base import ToolContext
@@ -80,6 +80,10 @@ def main() -> None:
         _run_case(
             "avoid_policy_from_ordinary_event",
             lambda: _eval_no_policy_from_event(_case_config(config, eval_id, "ordinary_event"), eval_id),
+        ),
+        _run_case(
+            "explain_memory_promotion_gates",
+            lambda: _eval_memory_promotion_gate_metadata(),
         ),
         _run_case("map_repository", lambda: _eval_repo_map(_case_config(config, eval_id, "repo_map"))),
         _run_case(
@@ -429,6 +433,32 @@ def _eval_no_policy_from_event(config: AgentConfig, eval_id: str) -> dict[str, A
         }
     finally:
         agent.close()
+
+
+def _eval_memory_promotion_gate_metadata() -> dict[str, Any]:
+    signal = LearningSignal(
+        title="One-off repair recipe",
+        content="Run pytest once after editing a file.",
+        kind=MemoryKind.PROCEDURE,
+        source_layer=MemoryLayer.EPISODIC,
+        validation_score=0.9,
+        repeat_count=1,
+        requested_target_layer=MemoryLayer.PROCEDURAL,
+    )
+    decision = NestedLearningKernel().decide(signal)
+    payload = decision.to_payload()
+    raw_requirements = payload.get("promotion_requirements", {})
+    requirements = raw_requirements if isinstance(raw_requirements, dict) else {}
+    return {
+        "passed": (
+            not decision.accepted
+            and requirements.get("target_layer") == "procedural"
+            and requirements.get("min_repeat_count") == 2
+            and requirements.get("observed_repeat_count") == 1
+        ),
+        "tool_count": 0,
+        "context_chars": len(json.dumps(payload)),
+    }
 
 
 def _eval_repo_map(config: AgentConfig) -> dict[str, Any]:

--- a/src/nested_memvid_agent/nested_learning.py
+++ b/src/nested_memvid_agent/nested_learning.py
@@ -85,6 +85,7 @@ class LearningDecision:
     importance: float
     flow: ContextFlow
     optimizer_trace: OptimizerTrace
+    promotion_requirements: dict[str, object]
 
     @property
     def accepted(self) -> bool:
@@ -101,6 +102,7 @@ class LearningDecision:
             "importance": self.importance,
             "context_flow": self.flow.to_metadata(),
             "optimizer_trace": self.optimizer_trace.to_metadata(),
+            "promotion_requirements": self.promotion_requirements,
         }
 
 
@@ -163,8 +165,10 @@ class NestedLearningKernel:
 
     def decide(self, signal: LearningSignal, *, action: LearningAction = "write") -> LearningDecision:
         target_layer, reason = self._target(signal)
+        requested_or_target = signal.requested_target_layer or target_layer
         flow = _flow_for(signal.source_layer, target_layer)
         trace = _optimizer_trace(signal, target_layer)
+        requirements = _promotion_requirements(signal, requested_or_target)
         if target_layer is None:
             return LearningDecision(
                 action="reject",
@@ -175,6 +179,7 @@ class NestedLearningKernel:
                 importance=signal.importance,
                 flow=flow,
                 optimizer_trace=trace,
+                promotion_requirements=requirements,
             )
         return LearningDecision(
             action=action,
@@ -185,6 +190,7 @@ class NestedLearningKernel:
             importance=max(signal.importance, 0.65 if target_layer != MemoryLayer.WORKING else signal.importance),
             flow=flow,
             optimizer_trace=trace,
+            promotion_requirements=requirements,
         )
 
     def from_record(
@@ -305,6 +311,56 @@ def _flow_for(source: MemoryLayer, target: MemoryLayer | None) -> ContextFlow:
     if source == MemoryLayer.WORKING:
         return DEFAULT_CONTEXT_FLOWS["interaction_to_working"]
     return DEFAULT_CONTEXT_FLOWS["episode_to_semantic"]
+
+
+def _promotion_requirements(signal: LearningSignal, target: MemoryLayer | None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "target_layer": None if target is None else target.value,
+        "observed_validation_score": signal.validation_score,
+        "observed_repeat_count": signal.repeat_count,
+        "observed_explicit_instruction": signal.explicit_instruction,
+    }
+    if target == MemoryLayer.POLICY:
+        payload.update(
+            {
+                "min_validation_score": 0.97 if signal.requested_target_layer == MemoryLayer.POLICY else 0.95,
+                "min_repeat_count": 5,
+                "requires_explicit_instruction": True,
+            }
+        )
+    elif target == MemoryLayer.PROCEDURAL:
+        payload.update(
+            {
+                "min_validation_score": 0.78,
+                "min_repeat_count": 2,
+                "requires_explicit_instruction": False,
+            }
+        )
+    elif target == MemoryLayer.SEMANTIC:
+        payload.update(
+            {
+                "min_validation_score": 0.78,
+                "min_repeat_count": 1,
+                "requires_explicit_instruction": False,
+            }
+        )
+    elif target == MemoryLayer.EPISODIC:
+        payload.update(
+            {
+                "min_validation_score": 0.65,
+                "min_repeat_count": 1,
+                "requires_explicit_instruction": False,
+            }
+        )
+    else:
+        payload.update(
+            {
+                "min_validation_score": 0.65,
+                "min_repeat_count": 1,
+                "requires_explicit_instruction": False,
+            }
+        )
+    return payload
 
 
 def _optimizer_trace(signal: LearningSignal, target: MemoryLayer | None) -> OptimizerTrace:

--- a/tests/test_nested_learning.py
+++ b/tests/test_nested_learning.py
@@ -34,10 +34,36 @@ def test_kernel_rejects_policy_request_without_explicit_repeated_validation() ->
     )
 
     decision = NestedLearningKernel().decide(signal)
+    payload = decision.to_payload()
 
     assert not decision.accepted
     assert decision.target_layer is None
     assert decision.action == "reject"
+    assert payload["promotion_requirements"]["target_layer"] == "policy"
+    assert payload["promotion_requirements"]["requires_explicit_instruction"] is True
+    assert payload["promotion_requirements"]["min_repeat_count"] == 5
+    assert payload["promotion_requirements"]["observed_repeat_count"] == 1
+
+
+def test_kernel_exposes_procedural_gate_requirements_for_one_off_success() -> None:
+    signal = LearningSignal(
+        title="One-off repair recipe",
+        content="Run pytest once after editing a file.",
+        kind=MemoryKind.PROCEDURE,
+        source_layer=MemoryLayer.EPISODIC,
+        validation_score=0.9,
+        repeat_count=1,
+        requested_target_layer=MemoryLayer.PROCEDURAL,
+    )
+
+    decision = NestedLearningKernel().decide(signal)
+    requirements = decision.to_payload()["promotion_requirements"]
+
+    assert not decision.accepted
+    assert requirements["target_layer"] == "procedural"
+    assert requirements["min_validation_score"] == 0.78
+    assert requirements["min_repeat_count"] == 2
+    assert requirements["observed_repeat_count"] == 1
 
 
 def test_kernel_builds_record_with_optimizer_metadata() -> None:


### PR DESCRIPTION
## Summary
- add auditable promotion gate metadata to nested learning decisions
- expose validation/repeat/explicit-instruction thresholds alongside observed evidence
- add a golden eval case that proves one-off procedural attempts explain why they do not promote

## Validation
- python -m compileall -q src tests scripts
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- python scripts/run_golden_evals.py --backend memory --provider mock --memory-dir /tmp/kestrel-phase8-golden