### PR TITLE
feat: add diagnosis-gated repair validation

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -17,7 +17,8 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Provider capability metadata is exposed on built-in providers, and a retryable-error fallback wrapper can route from a primary provider to a configured secondary provider.
 - Built-in tool registry with structured exception boundaries, timeout enforcement, and exact-call approval gates for shell, file writes, patch application, tests, and Codex CLI delegation.
 - Self-diagnosis primitives can classify common provider/tool/test/import/permission/MCP/sandbox failures and recall similar procedural/episodic failure lessons before retry.
-- Safe self-repair now has branch-isolated repair primitives: `repair.prepare`, `repair.status`, `repair.apply_patch`, `repair.validate`, and `repair.rollback`.
+- Safe self-repair now has branch-isolated repair primitives: `repair.prepare`, `repair.status`, `repair.apply_patch`, `repair.validate`, `repair.orchestrate_validate`, and `repair.rollback`.
+- The first diagnosis-gated repair orchestration slice can run validation on an active repair branch, classify failures, recall prior lessons, and block repeated validation retries until the strategy changes.
 - Skills now have a first manifest validation gate plus persisted validation/provenance metadata for discovered instruction capsules.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
@@ -31,6 +32,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
+- Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
 
 ## Partially Implemented
 
@@ -41,7 +43,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Consolidation: capsule extraction and Nested Learning decisions exist, but auto-consolidation remains disabled by default and validation loops are still basic.
 - Self-diagnosis: first-pass classification and memory recall tools exist. A full executor retry gate that forces changed strategy before every retry is still incomplete.
 - Self-modification: the runtime can record validated self-improvement signals and policy candidates, but code changes and policy writes still require explicit gates.
-- Safe repair: branch preparation, patch application, targeted validation, status reporting, and rollback primitives exist. Full autonomous patch proposal, reviewer gating, and approval-before-commit orchestration are still incomplete.
+- Safe repair: branch preparation, patch application, targeted validation, diagnosis-gated retry assessment, status reporting, and rollback primitives exist. Full autonomous patch proposal, reviewer gating, and approval-before-commit orchestration are still incomplete.
 - Subagents: local subagent runs can be queued and tracked. True branch/worktree isolation and Codex-backed worker fan-out are still next steps.
 - Channels: inbound normalization and dry-run reply payloads are implemented. Production bot identity verification, Discord Gateway reads, and channel-specific rate-limit handling still need hardening.
 

--- a/src/nested_memvid_agent/diagnosis.py
+++ b/src/nested_memvid_agent/diagnosis.py
@@ -35,7 +35,7 @@ def classify_failure(failure_text: str, *, source: str = "") -> FailureClassific
             retryable=True,
             playbook=_playbook("missing_dependency"),
         )
-    if any(marker in lowered for marker in ("failed tests/", " assertionerror", "pytest", "== failures ==")):
+    if any(marker in lowered for marker in ("failed tests/", "assertionerror", "pytest", "== failures ==")):
         signals.append("pytest/test failure marker")
         return FailureClassification(
             category="test_failure",

--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -1100,6 +1100,104 @@ class RepairValidateTool(AgentTool):
             return self._result(call, success=False, content=str(exc), error="repair_validation_failed")
 
 
+class RepairOrchestrateValidateTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.orchestrate_validate",
+        description="Run repair validation on an active repair branch, classify failures, recall prior lessons, and gate unchanged retries.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "command": {"type": "array", "items": {"type": "string"}},
+                "timeout": {"type": "integer"},
+                "previous_command": {"type": "array", "items": {"type": "string"}},
+                "proposed_strategy": {"type": "string"},
+                "k": {"type": "integer", "minimum": 1, "maximum": 10},
+            },
+            "required": ["command"],
+        },
+        risk="high",
+        requires_approval=True,
+        capabilities=("safe-repair", "validation", "self-diagnosis", "failure-recall"),
+    )
+    allowed_first_tokens = RepairValidateTool.allowed_first_tokens
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        command_raw = arguments.get("command")
+        if not isinstance(command_raw, list) or not all(isinstance(item, str) for item in command_raw):
+            return self._result(call, success=False, content="command must be list[str]", error="bad_command")
+        command = list(command_raw)
+        if not command or Path(command[0]).name not in self.allowed_first_tokens:
+            return self._result(call, success=False, content="Command is not allowlisted", error="command_not_allowlisted")
+        try:
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            if not _is_repair_branch(branch):
+                return self._result(call, success=False, content=f"Not on a repair branch: {branch}", error="not_repair_branch", data={"branch": branch})
+            status = _git_output(context.workspace, ["git", "status", "--porcelain"])
+            completed = subprocess.run(  # noqa: S603 - intentionally allowlisted repair validation command
+                command,
+                cwd=context.workspace,
+                capture_output=True,
+                text=True,
+                timeout=int(arguments.get("timeout", 120)),
+                check=False,
+            )
+            validation_content = f"exit_code={completed.returncode}\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+            validation = {
+                "success": completed.returncode == 0,
+                "returncode": completed.returncode,
+                "content": validation_content,
+            }
+            diagnosis = None
+            recall = {"hits": [], "query": "", "retry_guidance": {"must_change_strategy_before_retry": False}}
+            retry_gate = {
+                "retry_allowed": True,
+                "must_change_strategy_before_retry": False,
+                "reason": "Validation passed; no retry needed." if completed.returncode == 0 else "No similar lesson was found; follow the diagnostic playbook.",
+                "strategy_changed": True,
+            }
+            next_action = "review_and_commit_only_after_approval" if completed.returncode == 0 else "retry_with_diagnostic_playbook"
+            if completed.returncode != 0:
+                classification = classify_failure(validation_content, source="repair.orchestrate_validate")
+                diagnosis = classification.to_payload()
+                recall = _recall_failure_lessons(context, classification.category, validation_content, max(1, min(int(arguments.get("k", 5)), 10)))
+                previous = arguments.get("previous_command")
+                previous_command = previous if isinstance(previous, list) and all(isinstance(item, str) for item in previous) else []
+                proposed_strategy = str(arguments.get("proposed_strategy", "")).strip()
+                has_lessons = bool(recall["hits"])
+                command_repeated = previous_command == command
+                strategy_changed = bool(proposed_strategy)
+                must_change = has_lessons and command_repeated
+                retry_allowed = not must_change or strategy_changed
+                retry_gate = {
+                    "retry_allowed": retry_allowed,
+                    "must_change_strategy_before_retry": must_change,
+                    "strategy_changed": strategy_changed,
+                    "command_repeated": command_repeated,
+                    "reason": "Similar prior lessons were found; change strategy before repeating the validation command."
+                    if must_change and not strategy_changed
+                    else "Changed strategy supplied; retry may proceed after applying the change."
+                    if must_change
+                    else "No repeated-command lesson gate was triggered.",
+                }
+                next_action = "apply_changed_strategy_then_retry" if retry_allowed and must_change else "change_strategy_before_retry" if not retry_allowed else "retry_with_diagnostic_playbook"
+            payload = {
+                "branch": branch,
+                "active_repair_branch": True,
+                "changed_files": _changed_files_from_status(status),
+                "validation": validation,
+                "diagnosis": diagnosis,
+                "recall": recall,
+                "retry_gate": retry_gate,
+                "next_action": next_action,
+                "commit_allowed": False,
+                "approval_required_before_commit": True,
+            }
+            return self._result(call, success=True, content=json.dumps(payload, indent=2), data=payload)
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_orchestration_failed")
+
+
 class RepairRollbackTool(AgentTool):
     spec = ToolSpec(
         name="repair.rollback",
@@ -1601,35 +1699,10 @@ class DiagnosisRecallTool(AgentTool):
             return self._result(call, success=False, content="Missing failure_text", error="missing_failure_text")
         classification = classify_failure(failure_text, source=str(arguments.get("source", "")))
         k = max(1, min(int(arguments.get("k", 5)), 10))
-        query = f"{classification.category} {failure_text}"
-        hits = context.memory.retrieve(
-            RetrievalQuery(
-                query=query,
-                layers=(MemoryLayer.PROCEDURAL, MemoryLayer.EPISODIC, MemoryLayer.WORKING),
-                k_per_layer=k,
-            )
-        )
-        rows = []
-        for hit in hits[:k]:
-            rows.append(
-                {
-                    "layer": hit.record.layer.value,
-                    "kind": hit.record.kind.value,
-                    "title": hit.record.title,
-                    "score": hit.score,
-                    "snippet": hit.snippet or hit.record.content[:500],
-                }
-            )
+        recall = _recall_failure_lessons(context, classification.category, failure_text, k)
         payload = {
             **classification.to_payload(),
-            "query": query,
-            "hits": rows,
-            "retry_guidance": {
-                "must_change_strategy_before_retry": bool(rows),
-                "reason": "Similar prior failures were found; use recalled lessons before repeating the action."
-                if rows
-                else "No prior lesson found; follow the diagnostic playbook and record validated findings.",
-            },
+            **recall,
         }
         return self._result(call, success=True, content=json.dumps(payload, indent=2), data=payload)
 
@@ -1642,6 +1715,7 @@ def build_default_tools() -> ToolRegistry:
     registry.register(RepairStatusTool())
     registry.register(RepairApplyPatchTool())
     registry.register(RepairValidateTool())
+    registry.register(RepairOrchestrateValidateTool())
     registry.register(RepairRollbackTool())
     registry.register(MemorySearchTool())
     registry.register(MemoryWriteTool())
@@ -1673,6 +1747,38 @@ def build_default_tools() -> ToolRegistry:
     registry.register(MemoryExportTool())
     registry.register(MemoryImportTool())
     return registry
+
+
+def _recall_failure_lessons(context: ToolContext, category: str, failure_text: str, k: int) -> dict[str, Any]:
+    query = f"{category} {failure_text}"
+    hits = context.memory.retrieve(
+        RetrievalQuery(
+            query=query,
+            layers=(MemoryLayer.PROCEDURAL, MemoryLayer.EPISODIC, MemoryLayer.WORKING),
+            k_per_layer=k,
+        )
+    )
+    rows = []
+    for hit in hits[:k]:
+        rows.append(
+            {
+                "layer": hit.record.layer.value,
+                "kind": hit.record.kind.value,
+                "title": hit.record.title,
+                "score": hit.score,
+                "snippet": hit.snippet or hit.record.content[:500],
+            }
+        )
+    return {
+        "query": query,
+        "hits": rows,
+        "retry_guidance": {
+            "must_change_strategy_before_retry": bool(rows),
+            "reason": "Similar prior failures were found; use recalled lessons before repeating the action."
+            if rows
+            else "No prior lesson found; follow the diagnostic playbook and record validated findings.",
+        },
+    }
 
 
 def _safe_branch_name(name: str) -> bool:

--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -106,6 +106,7 @@ _ENABLEMENT_BY_TOOL = {
     "repair.prepare": "allow_file_write",
     "repair.apply_patch": "allow_file_write",
     "repair.validate": "allow_shell",
+    "repair.orchestrate_validate": "allow_shell",
     "repair.rollback": "allow_file_write",
     "codex.exec": "allow_codex_cli",
 }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -202,6 +202,25 @@ def test_diagnosis_classify_identifies_test_failures(tmp_path: Path) -> None:
     assert result.data["playbook"]["next_actions"]
 
 
+def test_diagnosis_classify_identifies_bare_assertion_errors(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+
+    result = registry.execute(
+        ToolCall(
+            name="diagnosis.classify",
+            arguments={
+                "failure_text": "Traceback (most recent call last):\nAssertionError: expected fixed",
+                "source": "repair.validate",
+            },
+        ),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+
+    assert result.success
+    assert result.data["classification"] == "test_failure"
+
+
 def test_diagnosis_recall_searches_prior_failure_lessons(tmp_path: Path) -> None:
     memory = build_memory_system("memory", tmp_path / "memory")
     memory.put(
@@ -365,6 +384,88 @@ def test_repair_apply_validate_and_rollback_on_repair_branch(tmp_path: Path) -> 
     assert (tmp_path / "README.md").read_text() == "seed\n"
 
 
+def test_repair_orchestrate_validate_blocks_non_repair_branch(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(
+        name="repair.orchestrate_validate",
+        arguments={"command": ["python", "-c", "print('ok')"]},
+        id="repair_orchestrate_main",
+    )
+
+    result = registry.execute(call, _approved_context(memory, tmp_path, call, allow_shell=True))
+
+    assert not result.success
+    assert result.error == "not_repair_branch"
+
+
+def test_repair_orchestrate_validate_recalls_lessons_and_blocks_unchanged_retry(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "switch", "-c", "codex/repair-loop"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    memory.put(
+        MemoryRecord(
+            layer=MemoryLayer.PROCEDURAL,
+            kind=MemoryKind.PROCEDURE,
+            title="AssertionError repair lesson",
+            content="When repair validation reports AssertionError: expected fixed, inspect the failing assertion before retrying.",
+            confidence=0.9,
+        )
+    )
+    registry = build_default_tools()
+    command = ["python", "-c", "raise AssertionError('expected fixed')"]
+    call = ToolCall(
+        name="repair.orchestrate_validate",
+        arguments={"command": command, "previous_command": command, "proposed_strategy": ""},
+        id="repair_orchestrate_retry",
+    )
+
+    result = registry.execute(call, _approved_context(memory, tmp_path, call, allow_shell=True))
+
+    assert result.success
+    assert result.data["validation"]["success"] is False
+    assert result.data["diagnosis"]["classification"] == "test_failure"
+    assert result.data["recall"]["hits"]
+    assert result.data["retry_gate"]["retry_allowed"] is False
+    assert result.data["retry_gate"]["must_change_strategy_before_retry"] is True
+    assert result.data["next_action"] == "change_strategy_before_retry"
+
+
+def test_repair_orchestrate_validate_allows_changed_strategy_after_recall(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "switch", "-c", "codex/repair-loop-change"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    memory.put(
+        MemoryRecord(
+            layer=MemoryLayer.PROCEDURAL,
+            kind=MemoryKind.PROCEDURE,
+            title="AssertionError repair lesson",
+            content="When repair validation reports AssertionError: expected fixed, inspect the failing assertion before retrying.",
+            confidence=0.9,
+        )
+    )
+    registry = build_default_tools()
+    command = ["python", "-c", "raise AssertionError('expected fixed')"]
+    call = ToolCall(
+        name="repair.orchestrate_validate",
+        arguments={
+            "command": command,
+            "previous_command": command,
+            "proposed_strategy": "Inspect the failing assertion and update the expected value before retrying.",
+        },
+        id="repair_orchestrate_changed",
+    )
+
+    result = registry.execute(call, _approved_context(memory, tmp_path, call, allow_shell=True))
+
+    assert result.success
+    assert result.data["validation"]["success"] is False
+    assert result.data["recall"]["hits"]
+    assert result.data["retry_gate"]["retry_allowed"] is True
+    assert result.data["next_action"] == "apply_changed_strategy_then_retry"
+
+
 def test_default_registry_includes_spec_tools() -> None:
     registry = build_default_tools()
     names = {spec.name for spec in registry.specs()}
@@ -374,6 +475,7 @@ def test_default_registry_includes_spec_tools() -> None:
         "repair.apply_patch",
         "repair.validate",
         "repair.rollback",
+        "repair.orchestrate_validate",
         "diagnosis.classify",
         "diagnosis.recall",
         "repo.search",


### PR DESCRIPTION
## Summary
- add approval-gated repair.orchestrate_validate for diagnosis-gated repair validation
- require active repair branches, classify validation failures, recall prior lessons, and block repeated validation retries until the strategy changes
- tighten AssertionError diagnosis classification and reuse failure-recall payload logic

## Validation
- python -m compileall -q src tests scripts
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"