### PR TITLE
fix: make run and approval terminals replay-safe

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -33,6 +33,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 - Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
+- Terminal run records and approval decisions are replay-safe: late duplicate terminal transitions cannot overwrite original run results, and already-decided approval records cannot be flipped by replayed decisions.
 
 ## Partially Implemented
 
@@ -62,6 +63,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 
 - High-risk tools require both capability enablement (matching allow flag, where applicable) and explicit approval for the exact tool-call ID and arguments before execution.
 - Cancelled runs must not transition to completed, blocked, or failed after cancellation; lifecycle updates should use the guarded state transition helper.
+- Completed, failed, and cancelled runs are immutable even for repeated same-status transition attempts; approval requests are immutable after leaving `pending`.
 - Tool execution is bounded by `tool_timeout_seconds` / `NEST_AGENT_TOOL_TIMEOUT_SECONDS` and timeout failures are returned as structured tool errors.
 - New background runs persist a root task plus a small starter DAG with dependencies, required tools, risk, acceptance criteria, attempt count, and failure reason fields.
 - Ordinary conversation and observations must not write policy memory directly.

--- a/src/nested_memvid_agent/state_store.py
+++ b/src/nested_memvid_agent/state_store.py
@@ -11,6 +11,7 @@ from threading import RLock
 from typing import Any
 
 SCHEMA_VERSION = 5
+_TERMINAL_RUN_STATUSES = {"completed", "failed", "cancelled"}
 
 
 def utc_now() -> str:
@@ -124,6 +125,8 @@ class AgentStateStore:
             if current_row is None:
                 raise KeyError(f"Unknown run: {run_id}")
             current = _run_from_row(current_row)
+            if current.status in _TERMINAL_RUN_STATUSES:
+                return current
             if not _run_transition_allowed(current.status, status):
                 return current
             updates = dict(fields)
@@ -267,6 +270,14 @@ class AgentStateStore:
         result: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         with self._connect() as conn:
+            current = conn.execute(
+                "SELECT status FROM approval_requests WHERE approval_id = ?",
+                (approval_id,),
+            ).fetchone()
+            if current is None:
+                raise KeyError(f"Unknown approval: {approval_id}")
+            if str(current["status"]) != "pending":
+                return self.get_approval(approval_id)
             conn.execute(
                 """
                 UPDATE approval_requests

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -47,6 +47,32 @@ def test_state_store_tracks_runs_and_approvals(tmp_path: Path) -> None:
     assert decided["status"] == "approved"
 
 
+def test_state_store_approval_decisions_are_immutable_after_first_decision(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    state.create_run(
+        run_id="run_approval_once",
+        message="hello",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+    state.create_approval(
+        approval_id="approval_once",
+        run_id="run_approval_once",
+        tool_call_id="tool_shell",
+        tool_name="shell.run",
+        arguments={"command": ["echo", "hi"]},
+        risk="high",
+    )
+
+    approved = state.decide_approval("approval_once", status="approved", decision={"approved": True})
+    replayed_denial = state.decide_approval("approval_once", status="denied", decision={"approved": False})
+
+    assert approved["status"] == "approved"
+    assert replayed_denial["status"] == "approved"
+    assert replayed_denial["decision"] == {"approved": True}
+
+
 def test_state_store_enforces_run_lifecycle_transitions(tmp_path: Path) -> None:
     state = AgentStateStore(tmp_path / "state.db")
     state.create_run(
@@ -71,6 +97,38 @@ def test_state_store_enforces_run_lifecycle_transitions(tmp_path: Path) -> None:
     completed_after_cancel = state.transition_run("run_lifecycle", "completed", stop_reason="complete")
     assert completed_after_cancel.status == "cancelled"
     assert completed_after_cancel.stop_reason == "cancelled"
+
+
+def test_state_store_terminal_run_states_are_immutable_even_for_same_status(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    for terminal_status in ("completed", "failed", "cancelled"):
+        run_id = f"run_{terminal_status}"
+        state.create_run(
+            run_id=run_id,
+            message="hello",
+            session_id="session",
+            workspace=str(tmp_path),
+            model="mock",
+        )
+        if terminal_status == "completed":
+            state.transition_run(run_id, "running")
+            terminal = state.transition_run(run_id, terminal_status, stop_reason="original", assistant_message="original message")
+        else:
+            terminal = state.transition_run(run_id, terminal_status, stop_reason="original", error="original error")
+        assert terminal.status == terminal_status
+
+        late_same_status = state.transition_run(
+            run_id,
+            terminal_status,
+            stop_reason="late overwrite",
+            assistant_message="late message",
+            error="late error",
+        )
+
+        assert late_same_status.status == terminal_status
+        assert late_same_status.stop_reason == "original"
+        assert late_same_status.assistant_message != "late message"
+        assert late_same_status.error != "late error"
 
 
 def test_state_store_lists_sessions_from_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make completed/failed/cancelled run records immutable against late duplicate same-status transitions
- make approval decisions one-shot so replayed/conflicting decisions cannot flip approved/denied records
- document the replay-safety contract

## Validation
- pytest tests/test_full_agent_runtime.py::test_state_store_approval_decisions_are_immutable_after_first_decision tests/test_full_agent_runtime.py::test_state_store_terminal_run_states_are_immutable_even_for_same_status tests/test_cli.py::test_approval_subcommands_use_persistent_run_state -q
- python -m compileall -q src tests scripts
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"