### PR TITLE
feat: persist task diagnosis retry metadata

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -22,7 +22,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Skills now have a first manifest validation gate plus persisted validation/provenance metadata for discovered instruction capsules.
 - Local FastAPI control plane with background runs, SSE events, approvals, tools, MCP registry, skills registry, and memory search.
 - Multi-channel ingress for Telegram Bot API updates, Discord message/interaction-shaped payloads, and generic/custom webhooks, with CLI and API routes.
-- SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `5`.
+- SQLite state store for runs, run steps, approvals, MCP servers, skills, task nodes, and subagent runs, now initialized through schema version `6`.
 - Paper-guided nested learning kernel with context-flow metadata, optimizer traces, conservative continuum-memory routing, and a `memory.learn` tool/API path.
 - Memory learning decisions now expose explicit promotion gate metadata so rejected/accepted decisions can explain target layer, observed evidence, repeat-count thresholds, validation thresholds, and explicit-instruction requirements.
 - Run-scoped `complete.mv2` task capsules, preview-only capsule summaries, dry-run consolidation decisions, and approval-gated capsule apply.
@@ -30,6 +30,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - MCP server records now persist vetting metadata: transport/network exposure, secret-env requirements, per-tool risk/approval classification, risk reasons, and recommended trust posture.
 - MCP stdio servers now have a managed lazy session lifecycle with connect/disconnect/restart/health API routes, bounded operation timeouts, config-change teardown, and approval-by-default tool risk normalization.
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
+- Task nodes can now persist latest failure diagnosis and retry strategy metadata; failed subagents classify the failure, record a retry gate that requires changed strategy, and emit a diagnosis event tied back to the task.
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 - Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
@@ -65,7 +66,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Cancelled runs must not transition to completed, blocked, or failed after cancellation; lifecycle updates should use the guarded state transition helper.
 - Completed, failed, and cancelled runs are immutable even for repeated same-status transition attempts; approval requests are immutable after leaving `pending`.
 - Tool execution is bounded by `tool_timeout_seconds` / `NEST_AGENT_TOOL_TIMEOUT_SECONDS` and timeout failures are returned as structured tool errors.
-- New background runs persist a root task plus a small starter DAG with dependencies, required tools, risk, acceptance criteria, attempt count, and failure reason fields.
+- New background runs persist a root task plus a small starter DAG with dependencies, required tools, risk, acceptance criteria, attempt count, failure reason, diagnosis, and retry-strategy fields.
 - Ordinary conversation and observations must not write policy memory directly.
 - The Memvid backend must use `.mv2` files and preserve one file per memory layer.
 - `complete.mv2` is a run artifact under `.nest/runs/{run_id}/`, not a permanent memory layer.

--- a/src/nested_memvid_agent/run_manager.py
+++ b/src/nested_memvid_agent/run_manager.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from .agent import NestedMV2Agent
 from .app_factory import build_agent
 from .config import AgentConfig
+from .diagnosis import classify_failure
 from .event_bus import RunEventBus
 from .mcp_manager import MCPManager
 from .models import MemoryLayer
@@ -395,9 +396,28 @@ class RunManager:
                 )
             self.events.publish(run_id, "subagent.completed", asdict(updated))
         except Exception as exc:  # noqa: BLE001
-            updated = self.state.update_subagent_run(subagent_id, status="failed", error=f"{type(exc).__name__}: {exc}")
+            error_text = f"{type(exc).__name__}: {exc}"
+            updated = self.state.update_subagent_run(subagent_id, status="failed", error=error_text)
             if subagent.task_id:
-                self.state.update_task_node(subagent.task_id, status="failed", result={"error": updated.error})
+                diagnosis = classify_failure(error_text, source="subagent")
+                diagnosis_payload = diagnosis.to_payload()
+                failed_task = self.state.record_task_failure(
+                    subagent.task_id,
+                    failure_reason=error_text,
+                    diagnosis=diagnosis_payload,
+                    retry_strategy={
+                        "requires_changed_strategy": True,
+                        "retry_allowed": False,
+                        "reason": "subagent failure must be diagnosed and strategy must change before retry",
+                    },
+                    result={"error": updated.error},
+                )
+                self.events.publish(run_id, "task.failed", _task_payload(failed_task))
+                self.events.publish(
+                    run_id,
+                    "diagnosis.classified",
+                    {"task_id": subagent.task_id, "source": "subagent", **diagnosis_payload},
+                )
             self.events.publish(run_id, "subagent.failed", asdict(updated))
         finally:
             agent.close()

--- a/src/nested_memvid_agent/state_store.py
+++ b/src/nested_memvid_agent/state_store.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from threading import RLock
 from typing import Any
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 _TERMINAL_RUN_STATUSES = {"completed", "failed", "cancelled"}
 
 
@@ -53,6 +53,8 @@ class TaskNodeRecord:
     acceptance_criteria: tuple[str, ...] = ()
     attempt_count: int = 0
     failure_reason: str = ""
+    diagnosis: dict[str, Any] | None = None
+    retry_strategy: dict[str, Any] | None = None
     created_at: str = ""
     updated_at: str = ""
 
@@ -443,6 +445,8 @@ class AgentStateStore:
         acceptance_criteria: list[str] | tuple[str, ...] = (),
         attempt_count: int = 0,
         failure_reason: str = "",
+        diagnosis: dict[str, Any] | None = None,
+        retry_strategy: dict[str, Any] | None = None,
     ) -> TaskNodeRecord:
         now = utc_now()
         with self._connect() as conn:
@@ -451,8 +455,9 @@ class AgentStateStore:
                 INSERT INTO task_nodes (
                     task_id, run_id, parent_id, title, goal, profile, status, approved,
                     plan_json, result_json, dependencies_json, required_tools_json, risk,
-                    acceptance_criteria_json, attempt_count, failure_reason, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+                    acceptance_criteria_json, attempt_count, failure_reason, diagnosis_json,
+                    retry_strategy_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id,
@@ -470,6 +475,8 @@ class AgentStateStore:
                     json.dumps(list(acceptance_criteria)),
                     attempt_count,
                     failure_reason,
+                    json.dumps(diagnosis) if diagnosis is not None else None,
+                    json.dumps(retry_strategy) if retry_strategy is not None else None,
                     now,
                     now,
                 ),
@@ -486,6 +493,26 @@ class AgentStateStore:
         with self._connect() as conn:
             conn.execute(f"UPDATE task_nodes SET {assignments} WHERE task_id = ?", values)
         return self.get_task_node(task_id)
+
+    def record_task_failure(
+        self,
+        task_id: str,
+        *,
+        failure_reason: str,
+        diagnosis: dict[str, Any] | None = None,
+        retry_strategy: dict[str, Any] | None = None,
+        result: dict[str, Any] | None = None,
+    ) -> TaskNodeRecord:
+        task = self.get_task_node(task_id)
+        return self.update_task_node(
+            task_id,
+            status="failed",
+            attempt_count=task.attempt_count + 1,
+            failure_reason=failure_reason,
+            diagnosis=diagnosis or {},
+            retry_strategy=retry_strategy or {},
+            result=result or task.result,
+        )
 
     def get_task_node(self, task_id: str) -> TaskNodeRecord:
         with self._connect() as conn:
@@ -584,6 +611,9 @@ class AgentStateStore:
             if current < 5:
                 _apply_schema_v5(conn)
                 current = 5
+            if current < 6:
+                _apply_schema_v6(conn)
+                current = 6
             if current < SCHEMA_VERSION:
                 raise RuntimeError(f"Unsupported schema migration target: {current} -> {SCHEMA_VERSION}")
             if current == SCHEMA_VERSION:
@@ -771,6 +801,16 @@ def _apply_schema_v5(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE mcp_servers ADD COLUMN vetting_json TEXT NOT NULL DEFAULT '{}'")
 
 
+def _apply_schema_v6(conn: sqlite3.Connection) -> None:
+    existing = _columns(conn, "task_nodes")
+    for name, definition in {
+        "diagnosis_json": "TEXT",
+        "retry_strategy_json": "TEXT",
+    }.items():
+        if name not in existing:
+            conn.execute(f"ALTER TABLE task_nodes ADD COLUMN {name} {definition}")
+
+
 def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
 
@@ -882,6 +922,8 @@ def _task_from_row(row: sqlite3.Row) -> TaskNodeRecord:
         acceptance_criteria=tuple(json.loads(str(_row_get(row, "acceptance_criteria_json", "[]") or "[]"))),
         attempt_count=int(str(_row_get(row, "attempt_count", 0) or 0)),
         failure_reason=str(_row_get(row, "failure_reason", "") or ""),
+        diagnosis=_json_or_none(_row_get(row, "diagnosis_json")),
+        retry_strategy=_json_or_none(_row_get(row, "retry_strategy_json")),
         created_at=str(row["created_at"]),
         updated_at=str(row["updated_at"]),
     )
@@ -929,4 +971,8 @@ def _task_column(field: str) -> str:
         return "required_tools_json"
     if field == "acceptance_criteria":
         return "acceptance_criteria_json"
+    if field == "diagnosis":
+        return "diagnosis_json"
+    if field == "retry_strategy":
+        return "retry_strategy_json"
     return field

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -194,6 +194,75 @@ def test_state_store_persists_durable_task_graph_metadata(tmp_path: Path) -> Non
     assert updated.failure_reason == "test failure"
 
 
+def test_state_store_persists_task_diagnosis_and_retry_strategy(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    state.create_run(
+        run_id="run_retry",
+        message="fix failing tests",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+    state.create_task_node(
+        task_id="task_retry",
+        run_id="run_retry",
+        title="Validate repair",
+        goal="Run targeted validation",
+        profile="reviewer",
+        status="running",
+    )
+
+    failed = state.record_task_failure(
+        "task_retry",
+        failure_reason="pytest failed",
+        diagnosis={"classification": "test_failure", "confidence": 0.9},
+        retry_strategy={
+            "previous_command": "pytest tests/test_widget.py -q",
+            "next_command": "pytest tests/test_widget.py::test_edge -q",
+            "changed_strategy": "narrow to failing edge case",
+            "retry_allowed": True,
+        },
+    )
+
+    assert failed.status == "failed"
+    assert failed.attempt_count == 1
+    assert failed.failure_reason == "pytest failed"
+    assert failed.diagnosis == {"classification": "test_failure", "confidence": 0.9}
+    assert failed.retry_strategy["previous_command"] == "pytest tests/test_widget.py -q"
+    assert failed.retry_strategy["changed_strategy"] == "narrow to failing edge case"
+
+
+def test_state_store_record_task_failure_increments_attempts_and_preserves_latest_strategy(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    state.create_run(
+        run_id="run_retry_twice",
+        message="fix failing tests",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+    state.create_task_node(
+        task_id="task_retry_twice",
+        run_id="run_retry_twice",
+        title="Validate repair",
+        goal="Run targeted validation",
+        profile="reviewer",
+        status="running",
+        attempt_count=2,
+    )
+
+    failed = state.record_task_failure(
+        "task_retry_twice",
+        failure_reason="pytest still failed",
+        diagnosis={"classification": "test_failure"},
+        retry_strategy={"changed_strategy": "inspect fixture setup", "retry_allowed": False},
+    )
+
+    assert failed.attempt_count == 3
+    assert failed.diagnosis == {"classification": "test_failure"}
+    assert failed.retry_strategy == {"changed_strategy": "inspect fixture setup", "retry_allowed": False}
+
+
 def test_run_event_bus_redacts_persistent_and_live_payloads(tmp_path: Path) -> None:
     state = AgentStateStore(tmp_path / "state.db")
     state.create_run(
@@ -225,13 +294,14 @@ def test_state_store_initializes_version_and_indexes(tmp_path: Path) -> None:
     db_path = tmp_path / "state.db"
     state = AgentStateStore(db_path)
 
-    assert state.schema_version() == 5
+    assert state.schema_version() == 6
     with sqlite3.connect(db_path) as conn:
         run_indexes = {row[1] for row in conn.execute("PRAGMA index_list('runs')").fetchall()}
         approval_indexes = {row[1] for row in conn.execute("PRAGMA index_list('approval_requests')").fetchall()}
         step_indexes = {row[1] for row in conn.execute("PRAGMA index_list('run_steps')").fetchall()}
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
         mcp_columns = {row[1] for row in conn.execute("PRAGMA table_info('mcp_servers')").fetchall()}
+        task_columns = {row[1] for row in conn.execute("PRAGMA table_info('task_nodes')").fetchall()}
 
     assert "idx_runs_status" in run_indexes
     assert "idx_approval_requests_status" in approval_indexes
@@ -248,6 +318,7 @@ def test_state_store_initializes_version_and_indexes(tmp_path: Path) -> None:
         "last_latency_ms",
         "vetting_json",
     } <= mcp_columns
+    assert {"diagnosis_json", "retry_strategy_json"} <= task_columns
 
 
 def test_mcp_static_tools_enter_unified_registry(tmp_path: Path) -> None:
@@ -686,6 +757,48 @@ def test_run_manager_runs_mock_subagent(tmp_path: Path) -> None:
     assert "Mock response" in str(final["result"])
     graph = manager.task_graph(run.run_id)
     assert graph["subagents"]
+
+
+def test_run_manager_records_subagent_failure_diagnosis_on_task_node(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    run = manager.create_run(message="main run", session_id="session")
+    task = manager.state.create_task_node(
+        task_id="task_subagent_failure",
+        run_id=run.run_id,
+        title="Failing reviewer",
+        goal="Run failing validation",
+        profile="reviewer",
+        status="queued",
+        approved=True,
+    )
+    subagent = manager.state.create_subagent_run(
+        subagent_id="subagent_failure",
+        run_id=run.run_id,
+        task_id=task.task_id,
+        profile="reviewer",
+        goal="Run failing validation",
+        status="queued",
+    )
+
+    class FailingAgent:
+        def chat(self, *args: object, **kwargs: object) -> AgentTurnResult:
+            raise AssertionError("pytest failed for widget edge case")
+
+        def close(self) -> None:
+            return None
+
+    manager._build_agent = lambda config: FailingAgent()  # type: ignore[method-assign]
+
+    manager._run_subagent("thread", manager.config, subagent.subagent_id, run.run_id, "session")
+
+    failed_task = manager.state.get_task_node(task.task_id)
+    assert failed_task.status == "failed"
+    assert failed_task.attempt_count == 1
+    assert failed_task.diagnosis is not None
+    assert failed_task.diagnosis["classification"] == "test_failure"
+    assert failed_task.retry_strategy is not None
+    assert failed_task.retry_strategy["requires_changed_strategy"] is True
+    assert "AssertionError" in failed_task.failure_reason
 
 
 def test_run_manager_publishes_stream_tokens(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add schema v6 task-node diagnosis/retry-strategy metadata
- add record_task_failure helper that increments attempts and persists diagnosis/retry gate state
- record failed subagent diagnosis on linked task nodes and emit task/diagnosis events

## TDD
- RED verified for missing record_task_failure/task diagnosis persistence
- RED verified for subagent failure not updating task attempt/diagnosis metadata

## Validation
- python -m compileall -q src tests scripts
- pytest -q
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"