### PR TITLE
test: add full agent flow smoke coverage

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -35,6 +35,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 - Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
 - Terminal run records and approval decisions are replay-safe: late duplicate terminal transitions cannot overwrite original run results, and already-decided approval records cannot be flipped by replayed decisions.
+- Approval resume flow now records the executed tool result back onto the already-approved approval record without reopening or flipping the decision, and a full-flow smoke test covers run creation, approval blocking, exact-call approval, resume, tool result persistence, traces, task graph, and capsule creation together.
 
 ## Partially Implemented
 
@@ -80,11 +81,14 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 ## Validation Commands
 
 ```bash
-python -m compileall -q src scripts
-pytest -q
-RUN_MCP_INTEGRATION=1 pytest -q tests/integration
-RUN_MEMVID_INTEGRATION=1 pytest -q tests/integration
+python -m compileall -q src tests scripts
+python -m pytest -q
 python scripts/run_golden_evals.py --backend memory --provider mock
+PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
+RUN_MCP_INTEGRATION=1 python -m pytest -q tests/integration/test_mcp_stdio_integration.py
+RUN_MEMVID_INTEGRATION=1 python -m pytest -q tests/integration/test_memvid_backend_integration.py tests/integration/test_memvid_context_frames.py
 npm run test --prefix web
 npm run build --prefix web
 ```
+
+Use `python -m pytest` instead of a global `pytest` binary for optional integration tests so the fixture subprocesses inherit the same environment and installed extras (`mcp`, `memvid-sdk`).

--- a/scripts/run_golden_evals.py
+++ b/scripts/run_golden_evals.py
@@ -231,7 +231,7 @@ def _eval_shell_block(config: AgentConfig) -> dict[str, Any]:
             ToolCall(name="shell.run", arguments={"command": ["echo", "hi"]}),
             _tool_context(agent),
         )
-        return {"passed": not execution.success and execution.error == "approval_required", "tool_count": 1}
+        return {"passed": not execution.success and execution.error == "tool_disabled", "tool_count": 1}
     finally:
         agent.close()
 
@@ -490,19 +490,32 @@ def _eval_patch_and_test(config: AgentConfig) -> dict[str, Any]:
 +good
 """
     try:
-        patch_result = agent.tools.execute(ToolCall(name="patch.apply", arguments={"patch": patch}), _tool_context(agent))
-        test_result = agent.tools.execute(
-            ToolCall(
-                name="test.run",
-                arguments={
-                    "command": [
-                        "python3",
-                        "-c",
-                        "from pathlib import Path; assert Path('calc.txt').read_text() == 'good\\n'",
-                    ]
-                },
+        patch_call = ToolCall(name="patch.apply", arguments={"patch": patch})
+        patch_result = agent.tools.execute(
+            patch_call,
+            _tool_context(
+                agent,
+                approved_tool_call_ids=frozenset({patch_call.id}),
+                approved_tool_call_arguments={patch_call.id: patch_call.arguments},
             ),
-            _tool_context(agent),
+        )
+        test_call = ToolCall(
+            name="test.run",
+            arguments={
+                "command": [
+                    "python3",
+                    "-c",
+                    "from pathlib import Path; assert Path('calc.txt').read_text() == 'good\\n'",
+                ]
+            },
+        )
+        test_result = agent.tools.execute(
+            test_call,
+            _tool_context(
+                agent,
+                approved_tool_call_ids=frozenset({test_call.id}),
+                approved_tool_call_arguments={test_call.id: test_call.arguments},
+            ),
         )
         return {
             "passed": patch_result.success and test_result.success,
@@ -517,9 +530,14 @@ def _eval_patch_and_test(config: AgentConfig) -> dict[str, Any]:
 def _eval_honest_test_failure(config: AgentConfig) -> dict[str, Any]:
     agent = build_agent(replace(config, allow_shell=True))
     try:
+        call = ToolCall(name="test.run", arguments={"command": ["python3", "-c", "import sys; sys.exit(4)"]})
         execution = agent.tools.execute(
-            ToolCall(name="test.run", arguments={"command": ["python3", "-c", "import sys; sys.exit(4)"]}),
-            _tool_context(agent),
+            call,
+            _tool_context(
+                agent,
+                approved_tool_call_ids=frozenset({call.id}),
+                approved_tool_call_arguments={call.id: call.arguments},
+            ),
         )
         return {
             "passed": not execution.success and execution.error == "nonzero_exit" and "exit_code=4" in execution.content,
@@ -580,13 +598,21 @@ def _summary(results: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _tool_context(agent: Any, session_id: str = "golden") -> ToolContext:
+def _tool_context(
+    agent: Any,
+    session_id: str = "golden",
+    *,
+    approved_tool_call_ids: frozenset[str] = frozenset(),
+    approved_tool_call_arguments: dict[str, dict[str, Any]] | None = None,
+) -> ToolContext:
     return ToolContext(
         memory=agent.memory,
         config=agent.config,
         workspace=agent.config.workspace,
         event_log=agent.event_log,
         session_id=session_id,
+        approved_tool_call_ids=approved_tool_call_ids,
+        approved_tool_call_arguments=approved_tool_call_arguments,
     )
 
 

--- a/src/nested_memvid_agent/run_manager.py
+++ b/src/nested_memvid_agent/run_manager.py
@@ -319,12 +319,7 @@ class RunManager:
                     approved_tool_call_arguments={call.id: arguments},
                 ),
             )
-            self.state.decide_approval(
-                str(approval["approval_id"]),
-                status="approved",
-                decision={"approved": True, "arguments": arguments},
-                result=_execution_payload(execution),
-            )
+            self.state.record_approval_result(str(approval["approval_id"]), _execution_payload(execution))
             self.events.publish(run_id, "tool.executed", _execution_payload(execution))
             self.events.publish(run_id, "tool.completed" if execution.success else "tool.failed", _execution_payload(execution))
             continuation = (

--- a/src/nested_memvid_agent/state_store.py
+++ b/src/nested_memvid_agent/state_store.py
@@ -290,6 +290,28 @@ class AgentStateStore:
             )
         return self.get_approval(approval_id)
 
+    def record_approval_result(self, approval_id: str, result: dict[str, Any]) -> dict[str, Any]:
+        with self._connect() as conn:
+            current = conn.execute(
+                "SELECT status, result_json FROM approval_requests WHERE approval_id = ?",
+                (approval_id,),
+            ).fetchone()
+            if current is None:
+                raise KeyError(f"Unknown approval: {approval_id}")
+            if str(current["status"]) == "pending":
+                return self.get_approval(approval_id)
+            if current["result_json"] is not None:
+                return self.get_approval(approval_id)
+            conn.execute(
+                """
+                UPDATE approval_requests
+                SET result_json = ?, updated_at = ?
+                WHERE approval_id = ?
+                """,
+                (json.dumps(result), utc_now(), approval_id),
+            )
+        return self.get_approval(approval_id)
+
     def upsert_mcp_server(self, server: dict[str, Any]) -> dict[str, Any]:
         server_id = str(server["id"])
         now = utc_now()

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -9,13 +9,16 @@ from types import SimpleNamespace
 from typing import Any
 
 import nested_memvid_agent.mcp_manager as mcp_module
+from nested_memvid_agent.agent import AgentDependencies, NestedMV2Agent
 from nested_memvid_agent.config import AgentConfig
 from nested_memvid_agent.event_bus import RunEventBus
+from nested_memvid_agent.event_log import JsonlEventLog
+from nested_memvid_agent.llm.mock import MockLLMProvider
 from nested_memvid_agent.mcp_manager import MCPManager
 from nested_memvid_agent.models import MemoryKind, MemoryLayer, MemoryRecord
 from nested_memvid_agent.orchestrator import build_memory_system
 from nested_memvid_agent.run_manager import RunManager
-from nested_memvid_agent.runtime_models import AgentTurnResult
+from nested_memvid_agent.runtime_models import AgentTurnResult, LLMResponse, ToolCall
 from nested_memvid_agent.server import create_app
 from nested_memvid_agent.skill_manager import SkillManager, validate_skill_manifest
 from nested_memvid_agent.state_store import AgentStateStore
@@ -71,6 +74,29 @@ def test_state_store_approval_decisions_are_immutable_after_first_decision(tmp_p
     assert approved["status"] == "approved"
     assert replayed_denial["status"] == "approved"
     assert replayed_denial["decision"] == {"approved": True}
+
+
+def test_state_store_records_approval_result_without_flipping_decision(tmp_path: Path) -> None:
+    state = AgentStateStore(tmp_path / "state.db")
+    state.create_approval(
+        approval_id="approval_test",
+        run_id="run_test",
+        tool_call_id="call_test",
+        tool_name="test.run",
+        arguments={"command": ["python3", "-c", "print('ok')"]},
+        risk="high",
+    )
+
+    decided = state.decide_approval("approval_test", status="approved", decision={"approved": True})
+    assert decided["result"] is None
+
+    recorded = state.record_approval_result("approval_test", {"success": True, "content": "ok"})
+    assert recorded["status"] == "approved"
+    assert recorded["decision"] == {"approved": True}
+    assert recorded["result"] == {"success": True, "content": "ok"}
+
+    replay = state.record_approval_result("approval_test", {"success": False, "content": "late failure"})
+    assert replay["result"] == {"success": True, "content": "ok"}
 
 
 def test_state_store_enforces_run_lifecycle_transitions(tmp_path: Path) -> None:
@@ -705,6 +731,72 @@ def test_run_manager_completes_background_mock_run(tmp_path: Path) -> None:
     graph = manager.task_graph(run.run_id)
     assert graph["tasks"]
     assert graph["tasks"][0]["title"] == "Root objective"
+
+
+def test_full_agent_flow_blocks_approves_resumes_traces_and_capsules(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    manager.config = AgentConfig(
+        **{
+            **manager.config.__dict__,
+            "allow_shell": True,
+            "enable_task_capsules": True,
+        }
+    )
+    scripted = [
+        LLMResponse(
+            content="I need approval to run validation.",
+            tool_calls=(
+                ToolCall(
+                    name="test.run",
+                    arguments={"command": ["python3", "-c", "print('full-flow-ok')"]},
+                ),
+            ),
+        ),
+        LLMResponse(content="Validation completed after approval."),
+    ]
+
+    def build_scripted_agent(config: AgentConfig) -> NestedMV2Agent:
+        response = scripted.pop(0)
+        return NestedMV2Agent(
+            AgentDependencies(
+                memory=build_memory_system(config.backend, config.memory_dir),
+                llm=MockLLMProvider(canned=[response]),
+                tools=manager.build_registry(),
+                config=config,
+                event_log=JsonlEventLog(config.log_dir / "events.jsonl"),
+            )
+        )
+
+    manager._build_agent = build_scripted_agent  # type: ignore[method-assign]
+
+    run = manager.create_run(message="Run the full validation flow", session_id="session")
+    blocked = _wait_for_status(manager, run.run_id, {"blocked", "failed"})
+    assert blocked["status"] == "blocked"
+    assert blocked["stop_reason"] == "approval_required"
+
+    approvals = manager.state.list_approvals(status="pending")
+    assert len(approvals) == 1
+    approval = approvals[0]
+    assert approval["tool_name"] == "test.run"
+
+    manager.decide_approval(approval["approval_id"], approved=True, arguments=approval["arguments"])
+    final = _wait_for_status(manager, run.run_id, {"completed", "failed"})
+
+    assert final["status"] == "completed"
+    assert final["assistant_message"] == "Validation completed after approval."
+    decided = manager.state.list_approvals(status="approved")[0]
+    assert decided["result"]["success"] is True
+    assert "full-flow-ok" in decided["result"]["content"]
+
+    graph = manager.task_graph(run.run_id)
+    assert graph["tasks"]
+    trace = manager.run_trace(run.run_id)
+    event_types = [event["type"] for event in manager.state.list_run_steps(run.run_id)]
+    assert "approval.requested" in event_types
+    assert "tool.completed" in event_types
+    assert "run.completed" in event_types
+    assert trace["run"]["status"] == "completed"
+    assert (manager.config.memory_dir.parent / "runs" / run.run_id / "complete.mv2").exists()
 
 
 def test_run_manager_creates_durable_child_plan_for_multi_step_goal(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a full-flow smoke test for run creation, approval blocking, exact-call approval resume, tool result persistence, run trace, task graph, and task capsule creation
- preserve approval decision immutability while allowing the approved tool execution result to be recorded once
- update golden evals to satisfy exact-call approval gates for high-risk patch/test tools
- document full-flow validation commands and the python -m pytest integration-test requirement

## Validation
- python -m compileall -q src tests scripts
- python -m pytest -q
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- RUN_MCP_INTEGRATION=1 python -m pytest -q tests/integration/test_mcp_stdio_integration.py
- RUN_MEMVID_INTEGRATION=1 python -m pytest -q tests/integration/test_memvid_backend_integration.py tests/integration/test_memvid_context_frames.py
- npm run test --prefix web
- npm run build --prefix web

## Notes
- Installed local optional extras with python -m pip install -e '.[memvid,mcp]' to run MCP/Memvid integration tests in the active interpreter.