### PR TITLE
feat: expose scheduler ready task gates

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -31,6 +31,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - MCP stdio servers now have a managed lazy session lifecycle with connect/disconnect/restart/health API routes, bounded operation timeouts, config-change teardown, and approval-by-default tool risk normalization.
 - First task-graph and subagent run records exist, with durable task metadata, deterministic starter plan decomposition, in-process planner/worker/reviewer profiles, and UI/API surfaces.
 - Task nodes can now persist latest failure diagnosis and retry strategy metadata; failed subagents classify the failure, record a retry gate that requires changed strategy, and emit a diagnosis event tied back to the task.
+- The task graph now exposes deterministic `ready_tasks` for scheduler/resume work: only approved queued/approved tasks with completed dependencies are eligible, and failed retry tasks remain blocked until their retry strategy explicitly allows a changed strategy.
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 - Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
@@ -53,7 +54,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 ## Not Done Yet
 
 - Native OpenAI streaming deltas and broader provider integration tests for OpenRouter/Anthropic/Ollama-style adapters.
-- Full durable multi-step planner/executor/reviewer loop with resumable goals, retries, and review gates.
+- Full durable multi-step planner/executor/reviewer loop with automated execution of scheduler-selected tasks and reviewer gates.
 - Production authentication, authorization, and user/session isolation for the UI/API.
 - Production webhook signature verification and secret rotation for external channel endpoints.
 - Robust MCP SSE/streamable HTTP transport fixtures and failure-recovery soak testing.

--- a/src/nested_memvid_agent/run_manager.py
+++ b/src/nested_memvid_agent/run_manager.py
@@ -204,8 +204,23 @@ class RunManager:
         self.state.get_run(run_id)
         return {
             "tasks": [_task_payload(task) for task in self.state.list_task_nodes(run_id)],
+            "ready_tasks": self.ready_tasks(run_id),
             "subagents": [asdict(subagent) for subagent in self.state.list_subagent_runs(run_id)],
         }
+
+    def ready_tasks(self, run_id: str) -> list[dict[str, Any]]:
+        self.state.get_run(run_id)
+        tasks = self.state.list_task_nodes(run_id)
+        by_id = {task.task_id: task for task in tasks}
+        ready: list[dict[str, Any]] = []
+        for task in tasks:
+            reason = _task_scheduler_reason(task, by_id)
+            if reason is None:
+                continue
+            payload = _task_payload(task)
+            payload["scheduler_reason"] = reason
+            ready.append(payload)
+        return ready
 
     def approve_task(self, run_id: str, task_id: str) -> dict[str, Any]:
         self.state.get_run(run_id)
@@ -567,6 +582,23 @@ def _task_payload(task: TaskNodeRecord) -> dict[str, Any]:
     payload["required_tools"] = list(task.required_tools)
     payload["acceptance_criteria"] = list(task.acceptance_criteria)
     return payload
+
+
+def _task_scheduler_reason(task: TaskNodeRecord, by_id: dict[str, TaskNodeRecord]) -> str | None:
+    if not task.approved:
+        return None
+    if task.status not in {"queued", "approved"}:
+        return None
+    if not all(by_id.get(dependency) and by_id[dependency].status == "completed" for dependency in task.dependencies):
+        return None
+    retry = task.retry_strategy or {}
+    if retry.get("requires_changed_strategy"):
+        if retry.get("retry_allowed") is not True or not str(retry.get("changed_strategy") or "").strip():
+            return None
+        return "retry_strategy_changed"
+    if task.attempt_count > 0:
+        return "retry_ready"
+    return "dependencies_satisfied"
 
 
 def _initial_task_plan(message: str) -> list[dict[str, Any]]:

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -816,6 +816,95 @@ def test_run_manager_creates_durable_child_plan_for_multi_step_goal(tmp_path: Pa
     assert child_tasks[1]["required_tools"]
 
 
+def test_run_manager_ready_tasks_respect_dependencies_and_approval(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    run = manager.state.create_run(
+        run_id="run_ready_dependencies",
+        message="Schedule dependent tasks",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+    root = manager.state.create_task_node(
+        task_id="task_root_ready",
+        run_id=run.run_id,
+        title="Ready root",
+        goal="No dependencies",
+        profile="worker",
+        status="queued",
+        approved=True,
+    )
+    dependent = manager.state.create_task_node(
+        task_id="task_dependent_ready",
+        run_id=run.run_id,
+        title="Dependent task",
+        goal="Waits for root",
+        profile="worker",
+        status="queued",
+        approved=True,
+        dependencies=[root.task_id],
+    )
+    manager.state.create_task_node(
+        task_id="task_unapproved",
+        run_id=run.run_id,
+        title="Needs approval",
+        goal="Risky task",
+        profile="worker",
+        status="queued",
+        approved=False,
+    )
+
+    ready = manager.ready_tasks(run.run_id)
+    assert [task["task_id"] for task in ready] == [root.task_id]
+
+    manager.state.update_task_node(root.task_id, status="completed")
+    ready_after_dependency = manager.ready_tasks(run.run_id)
+    assert dependent.task_id in [task["task_id"] for task in ready_after_dependency]
+    assert "task_unapproved" not in [task["task_id"] for task in ready_after_dependency]
+
+
+def test_run_manager_ready_tasks_block_failed_retries_until_strategy_changes(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    run = manager.state.create_run(
+        run_id="run_retry_gate",
+        message="Retry failed validation",
+        session_id="session",
+        workspace=str(tmp_path),
+        model="mock",
+    )
+    task = manager.state.create_task_node(
+        task_id="task_retry_gate",
+        run_id=run.run_id,
+        title="Retry gated task",
+        goal="Validate repair",
+        profile="worker",
+        status="failed",
+        approved=True,
+        retry_strategy={
+            "requires_changed_strategy": True,
+            "retry_allowed": False,
+            "reason": "same validation command already failed",
+        },
+    )
+
+    assert task.task_id not in [candidate["task_id"] for candidate in manager.ready_tasks(run.run_id)]
+
+    manager.state.update_task_node(
+        task.task_id,
+        status="queued",
+        retry_strategy={
+            "requires_changed_strategy": True,
+            "retry_allowed": True,
+            "changed_strategy": "narrow validation to failing test before full suite",
+        },
+    )
+
+    ready = manager.ready_tasks(run.run_id)
+    assert task.task_id in [candidate["task_id"] for candidate in ready]
+    retry_candidate = next(candidate for candidate in ready if candidate["task_id"] == task.task_id)
+    assert retry_candidate["scheduler_reason"] == "retry_strategy_changed"
+
+
 def test_run_manager_trace_includes_context_memory_and_tool_events(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
     run = manager.create_run(message="hello", session_id="session")


### PR DESCRIPTION
## Summary
- expose deterministic ready_tasks on the run task graph
- gate scheduler candidates by approval, completed dependencies, and retry strategy
- block failed retries until a changed retry strategy is explicitly allowed
- add TDD coverage for dependency/approval gating and retry-strategy gating
- update implementation status docs

## Validation
- python -m compileall -q src tests scripts
- python -m pytest -q
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- RUN_MCP_INTEGRATION=1 python -m pytest -q tests/integration/test_mcp_stdio_integration.py
- RUN_MEMVID_INTEGRATION=1 python -m pytest -q tests/integration/test_memvid_backend_integration.py tests/integration/test_memvid_context_frames.py
- npm run test --prefix web
- npm run build --prefix web