### PR TITLE
feat: require repair review gate before commit

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -35,6 +35,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Provider failures emit structured `diagnosis.classified` events so traces can explain the failure category and suggested playbook.
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 - Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
+- Repair commits on repair branches now require a durable `repair.review` artifact tied to a successful validation result and the current diff hash; `git.commit` refuses repair-branch commits when the review is missing, stale, or for a different branch.
 - Terminal run records and approval decisions are replay-safe: late duplicate terminal transitions cannot overwrite original run results, and already-decided approval records cannot be flipped by replayed decisions.
 - Approval resume flow now records the executed tool result back onto the already-approved approval record without reopening or flipping the decision, and a full-flow smoke test covers run creation, approval blocking, exact-call approval, resume, tool result persistence, traces, task graph, and capsule creation together.
 

--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -1198,6 +1199,66 @@ class RepairOrchestrateValidateTool(AgentTool):
             return self._result(call, success=False, content=str(exc), error="repair_orchestration_failed")
 
 
+class RepairReviewTool(AgentTool):
+    spec = ToolSpec(
+        name="repair.review",
+        description="Create a durable reviewer gate artifact for a validated repair diff before commit.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "validation": {"type": "object"},
+                "summary": {"type": "string"},
+                "risks": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["validation"],
+        },
+        risk="medium",
+        capabilities=("safe-repair", "review-gate"),
+    )
+
+    def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:
+        call = ToolCall(name=self.spec.name, arguments=arguments)
+        validation = arguments.get("validation")
+        if not isinstance(validation, dict):
+            return self._result(call, success=False, content="validation must be an object", error="bad_validation")
+        if validation.get("success") is not True:
+            return self._result(call, success=False, content="Repair review requires successful validation.", error="validation_not_successful")
+        try:
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            if not _is_repair_branch(branch):
+                return self._result(call, success=False, content=f"Not on a repair branch: {branch}", error="not_repair_branch", data={"branch": branch})
+            diff = _git_output(context.workspace, ["git", "diff", "HEAD", "--"])
+            if not diff.strip():
+                return self._result(call, success=False, content="No repair diff found to review.", error="empty_repair_diff", data={"branch": branch})
+            status = _git_output(context.workspace, ["git", "status", "--porcelain"])
+            head = _git_output(context.workspace, ["git", "rev-parse", "HEAD"])
+            diff_hash = hashlib.sha256(diff.encode("utf-8")).hexdigest()
+            review_id = f"repair_review_{diff_hash[:16]}"
+            risks_arg = arguments.get("risks")
+            risks = [str(item) for item in risks_arg] if isinstance(risks_arg, list) else []
+            payload = {
+                "review_id": review_id,
+                "branch": branch,
+                "head_sha": head,
+                "diff_hash": diff_hash,
+                "changed_files": _changed_files_from_status(status),
+                "summary": str(arguments.get("summary", "")).strip(),
+                "risks": risks,
+                "validation": validation,
+                "commit_gate": {
+                    "commit_allowed": True,
+                    "approval_required_before_commit": True,
+                    "reason": "Successful validation and reviewer artifact are present; commit still requires exact-call approval.",
+                },
+            }
+            review_dir = context.workspace / ".nest" / "repair_reviews"
+            review_dir.mkdir(parents=True, exist_ok=True)
+            (review_dir / f"{review_id}.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+            return self._result(call, success=True, content=json.dumps(payload, indent=2), data=payload)
+        except Exception as exc:  # noqa: BLE001
+            return self._result(call, success=False, content=str(exc), error="repair_review_failed")
+
+
 class RepairRollbackTool(AgentTool):
     spec = ToolSpec(
         name="repair.rollback",
@@ -1292,7 +1353,7 @@ class GitCommitTool(AgentTool):
         description="Commit already-staged workspace changes. Requires explicit approval and never pushes.",
         parameters={
             "type": "object",
-            "properties": {"message": {"type": "string"}},
+            "properties": {"message": {"type": "string"}, "repair_review_id": {"type": "string"}},
             "required": ["message"],
         },
         risk="high",
@@ -1305,6 +1366,19 @@ class GitCommitTool(AgentTool):
         if not message:
             return self._result(call, success=False, content="Missing commit message", error="missing_message")
         try:
+            repair_review_id: str | None = None
+            branch = _git_output(context.workspace, ["git", "branch", "--show-current"])
+            if _is_repair_branch(branch):
+                review_check = _validate_repair_review_gate(context.workspace, branch, str(arguments.get("repair_review_id", "")).strip())
+                if not review_check["ok"]:
+                    return self._result(
+                        call,
+                        success=False,
+                        content=str(review_check["content"]),
+                        error=str(review_check["error"]),
+                        data={key: value for key, value in review_check.items() if key not in {"ok", "content", "error"}},
+                    )
+                repair_review_id = str(review_check["review_id"])
             completed = subprocess.run(  # noqa: S603 - fixed executable and arguments
                 ["git", "commit", "-m", message],
                 cwd=context.workspace,
@@ -1314,11 +1388,14 @@ class GitCommitTool(AgentTool):
                 check=False,
             )
             content = f"exit_code={completed.returncode}\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+            data: dict[str, Any] = {"returncode": completed.returncode}
+            if repair_review_id:
+                data["repair_review_id"] = repair_review_id
             return self._result(
                 call,
                 success=completed.returncode == 0,
                 content=content,
-                data={"returncode": completed.returncode},
+                data=data,
                 error=None if completed.returncode == 0 else "git_commit_failed",
             )
         except Exception as exc:  # noqa: BLE001
@@ -1716,6 +1793,7 @@ def build_default_tools() -> ToolRegistry:
     registry.register(RepairApplyPatchTool())
     registry.register(RepairValidateTool())
     registry.register(RepairOrchestrateValidateTool())
+    registry.register(RepairReviewTool())
     registry.register(RepairRollbackTool())
     registry.register(MemorySearchTool())
     registry.register(MemoryWriteTool())
@@ -1806,6 +1884,54 @@ def _git_output(workspace: Path, command: list[str]) -> str:
     if completed.returncode != 0:
         raise RuntimeError(f"git command failed ({completed.returncode}): {' '.join(command)}\n{completed.stderr}")
     return completed.stdout.strip()
+
+
+def _validate_repair_review_gate(workspace: Path, branch: str, review_id: str) -> dict[str, Any]:
+    if not review_id:
+        return {
+            "ok": False,
+            "error": "repair_review_required",
+            "content": "Repair branch commits require a repair_review_id from repair.review.",
+            "branch": branch,
+        }
+    if not review_id.startswith("repair_review_") or "/" in review_id or ".." in review_id:
+        return {"ok": False, "error": "invalid_repair_review_id", "content": f"Invalid repair_review_id: {review_id}", "branch": branch}
+    path = workspace / ".nest" / "repair_reviews" / f"{review_id}.json"
+    if not path.exists():
+        return {"ok": False, "error": "repair_review_not_found", "content": f"Repair review artifact not found: {review_id}", "branch": branch}
+    try:
+        review = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return {"ok": False, "error": "repair_review_invalid", "content": f"Repair review artifact is invalid JSON: {exc}", "branch": branch}
+    if review.get("branch") != branch:
+        return {
+            "ok": False,
+            "error": "repair_review_branch_mismatch",
+            "content": f"Repair review was created for {review.get('branch')}, not {branch}.",
+            "branch": branch,
+            "review_id": review_id,
+        }
+    if review.get("validation", {}).get("success") is not True or review.get("commit_gate", {}).get("commit_allowed") is not True:
+        return {
+            "ok": False,
+            "error": "repair_review_not_approved",
+            "content": "Repair review does not contain a successful validation commit gate.",
+            "branch": branch,
+            "review_id": review_id,
+        }
+    diff = _git_output(workspace, ["git", "diff", "HEAD", "--"])
+    diff_hash = hashlib.sha256(diff.encode("utf-8")).hexdigest()
+    if review.get("diff_hash") != diff_hash:
+        return {
+            "ok": False,
+            "error": "repair_review_stale",
+            "content": "Repair diff changed after review; run repair.review again before committing.",
+            "branch": branch,
+            "review_id": review_id,
+            "expected_diff_hash": review.get("diff_hash"),
+            "actual_diff_hash": diff_hash,
+        }
+    return {"ok": True, "review_id": review_id, "diff_hash": diff_hash, "branch": branch}
 
 
 def _changed_files_from_status(status: str) -> list[str]:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -476,6 +476,7 @@ def test_default_registry_includes_spec_tools() -> None:
         "repair.validate",
         "repair.rollback",
         "repair.orchestrate_validate",
+        "repair.review",
         "diagnosis.classify",
         "diagnosis.recall",
         "repo.search",
@@ -637,6 +638,79 @@ def test_lint_run_uses_shell_enablement_and_allowlist(tmp_path: Path, monkeypatc
 
     assert allowed.success
     assert "clean" in allowed.content
+
+
+def test_repair_review_creates_commit_gate_after_successful_validation(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "switch", "-c", "codex/repair-review"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("patched\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(
+        name="repair.review",
+        arguments={
+            "validation": {"success": True, "command": ["pytest", "-q"], "content": "passed"},
+            "summary": "README patch validated with tests.",
+        },
+    )
+
+    result = registry.execute(call, ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path))
+
+    assert result.success
+    assert result.data["commit_gate"]["commit_allowed"] is True
+    assert result.data["commit_gate"]["approval_required_before_commit"] is True
+    review_path = tmp_path / ".nest" / "repair_reviews" / f"{result.data['review_id']}.json"
+    assert review_path.exists()
+    assert json.loads(review_path.read_text())["diff_hash"] == result.data["diff_hash"]
+
+
+def test_git_commit_blocks_repair_branch_without_reviewer_gate(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "switch", "-c", "codex/repair-no-review"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("patched\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    before = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True).stdout.strip()
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(name="git.commit", arguments={"message": "repair commit"}, id="commit_repair_no_review")
+
+    result = registry.execute(call, _approved_context(memory, tmp_path, call))
+    after = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True).stdout.strip()
+
+    assert not result.success
+    assert result.error == "repair_review_required"
+    assert after == before
+
+
+def test_git_commit_allows_repair_branch_with_current_reviewer_gate(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "switch", "-c", "codex/repair-reviewed"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("patched\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    review = registry.execute(
+        ToolCall(
+            name="repair.review",
+            arguments={"validation": {"success": True, "command": ["pytest", "-q"]}, "summary": "validated"},
+        ),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+    call = ToolCall(
+        name="git.commit",
+        arguments={"message": "repair commit", "repair_review_id": review.data["review_id"]},
+        id="commit_repair_reviewed",
+    )
+
+    result = registry.execute(call, _approved_context(memory, tmp_path, call))
+    log = subprocess.run(["git", "log", "-1", "--pretty=%s"], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    assert result.success
+    assert log.stdout.strip() == "repair commit"
+    assert result.data["repair_review_id"] == review.data["review_id"]
 
 
 def test_git_commit_requires_approval_and_never_pushes(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add repair.review to create durable reviewer gate artifacts for validated repair diffs
- make git.commit refuse repair-branch commits without a current successful review artifact
- cover missing review, successful review/commit, and review artifact persistence in tests

## Validation
- python -m compileall -q src tests scripts
- python -m pytest -q
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- RUN_MCP_INTEGRATION=1 python -m pytest -q tests/integration/test_mcp_stdio_integration.py
- RUN_MEMVID_INTEGRATION=1 python -m pytest -q tests/integration/test_memvid_backend_integration.py tests/integration/test_memvid_context_frames.py
- npm run test --prefix web
- npm run build --prefix web