### PR TITLE
feat: seed repair review gate in task plans

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -36,6 +36,7 @@ This repository is a working local agent scaffold, not a finished Hermes/OpenCla
 - Repair mutation tools are high-risk, approval-gated, covered by exact-call approvals, disabled unless the matching capability is enabled, and refuse non-repair branches for patch/validate/rollback operations.
 - Diagnosis-gated repair validation must remain approval-gated, refuse non-repair branches, recall similar lessons on failure, and block repeated validation retries when prior lessons exist unless a changed strategy is supplied.
 - Repair commits on repair branches now require a durable `repair.review` artifact tied to a successful validation result and the current diff hash; `git.commit` refuses repair-branch commits when the review is missing, stale, or for a different branch.
+- Background repair/commit goals now seed a repair-specific task DAG that orders inspect → isolation → patch → validation → `repair.review` → `git.commit`, so the durable plan itself encodes the reviewer gate before commit.
 - Terminal run records and approval decisions are replay-safe: late duplicate terminal transitions cannot overwrite original run results, and already-decided approval records cannot be flipped by replayed decisions.
 - Approval resume flow now records the executed tool result back onto the already-approved approval record without reopening or flipping the decision, and a full-flow smoke test covers run creation, approval blocking, exact-call approval, resume, tool result persistence, traces, task graph, and capsule creation together.
 

--- a/src/nested_memvid_agent/run_manager.py
+++ b/src/nested_memvid_agent/run_manager.py
@@ -611,6 +611,73 @@ def _initial_task_plan(message: str) -> list[dict[str, Any]]:
     objective = message.strip() or "User objective"
     inspect_id = f"task_{uuid4().hex}"
     validate_id = f"task_{uuid4().hex}"
+    if _looks_like_repair_commit_request(objective):
+        prepare_id = f"task_{uuid4().hex}"
+        patch_id = f"task_{uuid4().hex}"
+        review_id = f"task_{uuid4().hex}"
+        commit_id = f"task_{uuid4().hex}"
+        return [
+            {
+                "task_id": inspect_id,
+                "title": "Inspect repair context",
+                "goal": f"Gather repository context and failure evidence for: {objective}",
+                "profile": "worker",
+                "dependencies": [],
+                "required_tools": ["repo.search", "repo.map", "memory.search", "context.pack"],
+                "risk": "low",
+                "acceptance_criteria": ["Relevant code, tests, and prior repair lessons are identified before mutation."],
+            },
+            {
+                "task_id": prepare_id,
+                "title": "Prepare repair isolation",
+                "goal": f"Create or confirm an isolated repair branch/worktree before changing files for: {objective}",
+                "profile": "worker",
+                "dependencies": [inspect_id],
+                "required_tools": ["repair.prepare", "repair.status"],
+                "risk": "high",
+                "acceptance_criteria": ["Mutation happens only on an approved repair branch/worktree."],
+            },
+            {
+                "task_id": patch_id,
+                "title": "Apply repair patch",
+                "goal": f"Apply the smallest repair patch for: {objective}",
+                "profile": "worker",
+                "dependencies": [prepare_id],
+                "required_tools": ["repair.apply_patch", "patch.apply"],
+                "risk": "high",
+                "acceptance_criteria": ["Patch is scoped to the diagnosed repair and path-safe."],
+            },
+            {
+                "task_id": validate_id,
+                "title": "Validate repair",
+                "goal": f"Run targeted validation and classify failures for: {objective}",
+                "profile": "worker",
+                "dependencies": [patch_id],
+                "required_tools": ["repair.orchestrate_validate", "repair.validate", "test.run", "lint.run"],
+                "risk": "high",
+                "acceptance_criteria": ["Targeted validation passes, or retry guidance records a changed strategy."],
+            },
+            {
+                "task_id": review_id,
+                "title": "Review repair before commit",
+                "goal": f"Create the durable repair.review artifact after successful validation for: {objective}",
+                "profile": "reviewer",
+                "dependencies": [validate_id],
+                "required_tools": ["repair.review", "git.diff", "repair.status"],
+                "risk": "medium",
+                "acceptance_criteria": ["repair.review records successful validation, current branch, changed files, and current diff hash."],
+            },
+            {
+                "task_id": commit_id,
+                "title": "Commit reviewed repair",
+                "goal": f"Commit only after repair.review created a current reviewer gate for: {objective}",
+                "profile": "worker",
+                "dependencies": [review_id],
+                "required_tools": ["git.commit"],
+                "risk": "high",
+                "acceptance_criteria": ["git.commit includes the current repair.review id and still requires exact-call approval."],
+            },
+        ]
     return [
         {
             "task_id": inspect_id,
@@ -643,6 +710,18 @@ def _initial_task_plan(message: str) -> list[dict[str, Any]]:
             "acceptance_criteria": ["Remaining risks or next steps are explicit."],
         },
     ]
+
+
+def _looks_like_repair_commit_request(message: str) -> bool:
+    normalized = message.lower()
+    repair_terms = ("repair", "fix", "patch", "failing", "failure", "bug")
+    commit_terms = ("commit", "merge", "pr", "pull request")
+    validation_terms = ("validate", "test", "lint", "check")
+    return (
+        any(term in normalized for term in repair_terms)
+        and any(term in normalized for term in commit_terms)
+        and any(term in normalized for term in validation_terms)
+    )
 
 
 def _trace_category(event: dict[str, Any]) -> str:

--- a/tests/test_full_agent_runtime.py
+++ b/tests/test_full_agent_runtime.py
@@ -816,6 +816,26 @@ def test_run_manager_creates_durable_child_plan_for_multi_step_goal(tmp_path: Pa
     assert child_tasks[1]["required_tools"]
 
 
+def test_run_manager_repair_plan_inserts_review_gate_before_commit(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    run = manager.create_run(message="Fix the failing test, validate it, review the repair, and commit it", session_id="session")
+
+    graph = manager.task_graph(run.run_id)
+    child_tasks = graph["tasks"][1:]
+    titles = [task["title"] for task in child_tasks]
+
+    assert "Review repair before commit" in titles
+    assert "Commit reviewed repair" in titles
+    review_task = child_tasks[titles.index("Review repair before commit")]
+    commit_task = child_tasks[titles.index("Commit reviewed repair")]
+    validate_task = next(task for task in child_tasks if task["title"] == "Validate repair")
+    assert "repair.review" in review_task["required_tools"]
+    assert "git.commit" in commit_task["required_tools"]
+    assert validate_task["task_id"] in review_task["dependencies"]
+    assert review_task["task_id"] in commit_task["dependencies"]
+    assert any("repair.review" in criterion for criterion in commit_task["acceptance_criteria"])
+
+
 def test_run_manager_ready_tasks_respect_dependencies_and_approval(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
     run = manager.state.create_run(


### PR DESCRIPTION
## Summary
- add repair-specific background task DAGs for repair/validate/commit goals
- order durable repair plans through inspect, isolation, patch, validation, repair.review, then git.commit
- add a regression test proving git.commit depends on the repair.review task

## Validation
- python -m compileall -q src tests scripts
- python -m pytest -q
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- RUN_MCP_INTEGRATION=1 python -m pytest -q tests/integration/test_mcp_stdio_integration.py
- RUN_MEMVID_INTEGRATION=1 python -m pytest -q tests/integration/test_memvid_backend_integration.py tests/integration/test_memvid_context_frames.py
- npm run test --prefix web
- npm run build --prefix web