### PR TITLE
fix(installer): disable default server autostart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ DEFAULT_REPO="https://github.com/John-MiracleWorker/Kestrel.git"
 DEFAULT_HOME="${HOME}/.kestrel-agent"
 DEFAULT_EXTRAS="memvid,openai,server,mcp,dev"
 DEFAULT_PORT="8765"
-DEFAULT_START_SERVER="1"
-DEFAULT_OPEN_BROWSER="1"
+DEFAULT_START_SERVER="0"
+DEFAULT_OPEN_BROWSER="0"
 DEFAULT_SERVER_SESSION="kestrel-agent"
 
 usage() {
@@ -24,8 +24,8 @@ Environment options:
   KESTREL_EXTRAS        Python extras to install. Defaults to memvid,openai,server,mcp,dev.
   KESTREL_SKIP_WEB      Set to 1/true to skip npm ci and web build.
   KESTREL_SKIP_SMOKE    Set to 1/true to skip doctor/chat smoke checks.
-  KESTREL_START_SERVER  Set to 0/false to skip launching the local server and web UI. Defaults to 1.
-  KESTREL_OPEN_BROWSER  Set to 0/false to skip opening the web UI in your browser. Defaults to 1.
+  KESTREL_START_SERVER  Set to 1/true to launch the local server and web UI. Defaults to 0.
+  KESTREL_OPEN_BROWSER  Set to 1/true to open the web UI in your browser (when server launch is enabled). Defaults to 0.
   KESTREL_SERVER_SESSION Detached screen/tmux session name. Defaults to kestrel-agent.
   KESTREL_SERVER_LOG    Server log path. Defaults to $KESTREL_HOME/.nest/server.log.
   KESTREL_SERVER_PID    Server PID file path. Defaults to $KESTREL_HOME/.nest/server.pid.

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -117,13 +117,13 @@ def test_install_dry_run_uses_memvid_mock_defaults(tmp_path: Path) -> None:
     assert "nest-agent init --backend memvid --memory-dir .nest/memory" in result.stdout
     assert "nest-agent memory verify --backend memvid --memory-dir .nest/memory" in result.stdout
     assert 'nest-agent chat --backend memory --memory-dir .nest/install-smoke-memory --provider mock --model mock --message "hello from one-shot install"' in result.stdout
-    assert "server auto-start: enabled" in result.stdout
-    assert "browser open: enabled" in result.stdout
+    assert "server auto-start: disabled" in result.stdout
+    assert "browser open: disabled" in result.stdout
     assert "server pid:" in result.stdout
     assert ".nest/server.pid" in result.stdout
-    assert "health check: http://127.0.0.1:8765/api/health" in result.stdout
-    assert "web UI: http://127.0.0.1:8765/" in result.stdout
-    assert "nest-agent server --backend memvid --memory-dir .nest/memory --provider mock --model mock --host 127.0.0.1 --port 8765" in result.stdout
+    assert "health check: skipped" in result.stdout
+    assert "web UI: skipped" in result.stdout
+    assert "launch command: skipped" in result.stdout
     assert "NEST_AGENT_ALLOW_SHELL=false" in result.stdout
     assert "NEST_AGENT_ALLOW_POLICY_WRITES=false" in result.stdout
     assert "NEST_AGENT_ALLOW_PLUGIN_INSTALL=false" in result.stdout


### PR DESCRIPTION
### Motivation
- Prevent a default-on local API exposure by making the one-shot installer opt-in for launching the detached web/API server and opening a browser.
- Align installer help text and dry-run output with safer defaults that do not start an unauthenticated local server.

### Description
- Change `DEFAULT_START_SERVER` from `"1"` to `"0"` so the installer does not auto-start the server by default in `install.sh`.
- Change `DEFAULT_OPEN_BROWSER` from `"1"` to `"0"` so the browser is not opened by default in `install.sh`.
- Update the `install.sh` help text to state the new default opt-in semantics for `KESTREL_START_SERVER` and `KESTREL_OPEN_BROWSER`.
- Update `tests/test_install_script.py` assertions to expect the dry-run output to show the server/browser as disabled and health/launch items as `skipped`.

### Testing
- Ran `pytest -q tests/test_install_script.py` and the test suite passed.
- Ran full `pytest -q` in this environment and collection failed due to missing optional test dependencies (`fastapi`, `pydantic`), which are unrelated to the installer change and block full test collection here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4da10524832ab6153fb83e4e7d53)