### PR TITLE
fix: gate and require approval for memory.correct

### DIFF
--- a/src/nested_memvid_agent/tools/builtin.py
+++ b/src/nested_memvid_agent/tools/builtin.py
@@ -907,7 +907,8 @@ class MemoryCorrectTool(AgentTool):
             },
             "required": ["target_record_id", "correction_text"],
         },
-        risk="medium",
+        risk="high",
+        requires_approval=True,
     )
 
     def run(self, arguments: dict[str, Any], context: ToolContext) -> ToolExecution:

--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -139,6 +139,7 @@ _ENABLEMENT_BY_TOOL = {
     "plugin.install": "allow_plugin_install",
     "git.commit": "allow_git_commit",
     "memory.import": "allow_memory_import",
+    "memory.correct": "allow_memory_import",
     "web.search": "allow_web",
     "web.fetch": "allow_web",
     "self.propose_change": "allow_self_modification",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2093,18 +2093,45 @@ def test_memory_correct_writes_correction_and_hides_superseded_target(tmp_path: 
         )
     )
 
-    result = build_default_tools().execute(
-        ToolCall(
-            name="memory.correct",
-            arguments={
-                "target_record_id": target_id,
-                "correction_text": "Feature alpha is not enabled.",
-                "evidence": [
-                    {"source": "user", "locator": "turn-1", "quote": "actually, alpha is off"}
-                ],
-            },
-        ),
+    call = ToolCall(
+        name="memory.correct",
+        id="correct_alpha",
+        arguments={
+            "target_record_id": target_id,
+            "correction_text": "Feature alpha is not enabled.",
+            "evidence": [
+                {"source": "user", "locator": "turn-1", "quote": "actually, alpha is off"}
+            ],
+        },
+    )
+    registry = build_default_tools()
+    disabled = registry.execute(
+        call,
         ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+    assert not disabled.success
+    assert disabled.error == "tool_disabled"
+
+    blocked = registry.execute(
+        call,
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_memory_import=True),
+            workspace=tmp_path,
+        ),
+    )
+    assert not blocked.success
+    assert blocked.error == "approval_required"
+
+    result = registry.execute(
+        call,
+        ToolContext(
+            memory=memory,
+            config=AgentConfig(allow_memory_import=True),
+            workspace=tmp_path,
+            approved_tool_call_ids=frozenset({"correct_alpha"}),
+            approved_tool_call_arguments={"correct_alpha": call.arguments},
+        ),
     )
 
     assert result.success


### PR DESCRIPTION
### Motivation
- `memory.correct` could perform durable mutations and tombstoning of high-trust memory layers without approval or capability gating, allowing attacker-controlled correction text to persistently poison memory.
- The tool was registered as medium risk and ungated while correction frames were created with fixed `confidence=0.86`, which could bypass the normal write/promotion gates for semantic/procedural/self layers.

### Description
- Mark `memory.correct` as high risk and require exact-call approval by setting `requires_approval=True` on the tool `ToolSpec` (in `src/nested_memvid_agent/tools/builtin.py`).
- Add a capability gate by mapping `"memory.correct"` to `allow_memory_import` in `_ENABLEMENT_BY_TOOL` so the tool is disabled by default (in `src/nested_memvid_agent/tools/registry.py`).
- Update `tests/test_tools.py::test_memory_correct_writes_correction_and_hides_superseded_target` to assert disabled-by-default behavior, blocking when enabled without approval, and successful execution only after exact-call approval with matching arguments.
- Changes are minimal and preserve existing intended functionality when the config flag is enabled and an exact approval is provided.

### Testing
- Ran `pytest -q tests/test_tools.py -k memory_correct` and the focused test passed successfully.
- Ran `pytest -q` which failed during collection due to missing optional test dependencies (`fastapi`/`pydantic`) in the current environment, so full-suite validation is pending in CI with proper deps installed.
- The updated test verifies the disabled, approval-blocked, and approved-success paths for `memory.correct` and passed locally for the targeted scenario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3a8a6498832aabcd55686eeff0ed)