### PR TITLE
fix: prevent file.read from exposing broker vault secrets

### DIFF
--- a/src/nested_memvid_agent/tools/workspace_tools.py
+++ b/src/nested_memvid_agent/tools/workspace_tools.py
@@ -49,6 +49,7 @@ class ReadFileTool(AgentTool):
         call = ToolCall(name=self.spec.name, arguments=arguments)
         try:
             path = _safe_path(context.workspace, str(arguments.get("path", "")))
+            _assert_not_secret_store_path(context.workspace, path)
             max_chars = int(arguments.get("max_chars", 20_000))
             text = path.read_text(errors="replace")[:max_chars]
             return self._result(call, success=True, content=text, data={"path": str(path), "chars": len(text)})
@@ -180,6 +181,13 @@ def _safe_path(root: Path, relative: str) -> Path:
     if root_resolved not in path.parents and path != root_resolved:
         raise ValueError(f"Path escapes workspace: {relative}")
     return path
+
+
+def _assert_not_secret_store_path(workspace: Path, path: Path) -> None:
+    workspace_root = workspace.resolve()
+    secrets_root = (workspace_root / ".nest" / "secrets").resolve()
+    if path == secrets_root or secrets_root in path.parents:
+        raise ValueError("Reading broker secret files is not allowed.")
 
 
 def _skip_repo_name(name: str) -> bool:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -235,6 +235,21 @@ def test_file_read_rejects_path_escape(tmp_path: Path) -> None:
     assert result.error == "file_read_failed"
 
 
+def test_file_read_rejects_secret_store_path(tmp_path: Path) -> None:
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    secrets_dir = tmp_path / ".nest" / "secrets"
+    secrets_dir.mkdir(parents=True, exist_ok=True)
+    (secrets_dir / "local_vault.json").write_text('{"secrets": {"token": {"value": "raw"}}}')
+    result = registry.execute(
+        ToolCall(name="file.read", arguments={"path": ".nest/secrets/local_vault.json"}),
+        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    )
+    assert not result.success
+    assert result.error == "file_read_failed"
+    assert "not allowed" in result.content.lower()
+
+
 def test_high_risk_tool_requires_enablement(tmp_path: Path) -> None:
     memory = build_memory_system("memory", tmp_path / "memory")
     registry = build_default_tools()


### PR DESCRIPTION
### Motivation
- The secret broker persisted raw secret values into `.nest/secrets/local_vault.json` under the workspace which could be exfiltrated via the low-risk `file.read` tool. 
- The intent is to preserve workspace file reads while ensuring the broker vault remains inaccessible to non-approved tools.

### Description
- Added a path guard function `_assert_not_secret_store_path(workspace, path)` to detect and deny reads under the workspace `.nest/secrets` directory. 
- Invoked the guard from `ReadFileTool.run` immediately after `_safe_path(...)` resolution to preserve existing workspace-safety checks while blocking broker vault access. 
- Added a regression test `test_file_read_rejects_secret_store_path` to verify that reading `.nest/secrets/local_vault.json` is rejected with an informative error.
- Changes touched `src/nested_memvid_agent/tools/workspace_tools.py` and `tests/test_tools.py`.

### Testing
- Ran `pytest -q tests/test_tools.py::test_file_read_rejects_path_escape tests/test_tools.py::test_file_read_rejects_secret_store_path` and both tests passed. 
- Ran full `pytest -q` in this environment which failed during collection due to missing optional dependencies (`fastapi`, `pydantic`) unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a38dc1fd0832aac7c6f8be989d91c)