### PR TITLE
fix: disable git hooks during worker worktree setup

### DIFF
--- a/src/nested_memvid_agent/worker_isolation.py
+++ b/src/nested_memvid_agent/worker_isolation.py
@@ -47,7 +47,7 @@ def prepare_git_worktree(
 
 def _git_output(cwd: Path, *args: str) -> str:
     completed = subprocess.run(  # noqa: S603 - fixed executable with argument vector  # nosec
-        ["git", *args],
+        ["git", "-c", "core.hooksPath=/dev/null", *args],
         cwd=cwd,
         capture_output=True,
         text=True,


### PR DESCRIPTION
### Motivation
- Prevent repository-configured git hooks (for example `post-checkout`) from running during `prepare_git_worktree`'s `git worktree add` invocation, which could lead to arbitrary code execution when worker isolation is enabled.

### Description
- Harden `_git_output` so git is invoked with `-c core.hooksPath=/dev/null`, disabling hook execution for all worker-isolation git subprocesses while preserving existing worktree behavior.

### Testing
- `pytest -q tests/test_full_agent_runtime.py::test_scheduler_task_uses_git_worktree_when_worker_isolation_enabled` was run and passed; a full `pytest -q` run was attempted but test collection failed in this environment due to missing optional dependencies (`fastapi`, `pydantic`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a38c37e90832aa728551fc84d7833)