### PR TITLE
security: gate repair.review behind approval and file-write enablement

### DIFF
--- a/src/nested_memvid_agent/tools/registry.py
+++ b/src/nested_memvid_agent/tools/registry.py
@@ -133,6 +133,7 @@ _ENABLEMENT_BY_TOOL = {
     "repair.apply_patch": "allow_file_write",
     "repair.validate": "allow_shell",
     "repair.orchestrate_validate": "allow_shell",
+    "repair.review": "allow_file_write",
     "repair.rollback": "allow_file_write",
     "codex.exec": "allow_codex_cli",
     "skill.install": "allow_file_write",

--- a/src/nested_memvid_agent/tools/repair_tools.py
+++ b/src/nested_memvid_agent/tools/repair_tools.py
@@ -495,6 +495,7 @@ class RepairReviewTool(AgentTool):
             "required": ["validation"],
         },
         risk="medium",
+        requires_approval=True,
         capabilities=("safe-repair", "review-gate"),
     )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1425,16 +1425,15 @@ def test_repair_e2e_smoke_reaches_reviewed_commit_gate_after_seeded_failure(tmp_
     assert validation.data["next_action"] == "create_repair_review_before_commit"
     assert validation.data["commit_allowed"] is False
 
-    review = registry.execute(
-        ToolCall(
-            name="repair.review",
-            arguments={
-                "validation": validation.data["validation"],
-                "summary": "Calculator repair validated by targeted pytest.",
-            },
-        ),
-        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    review_call = ToolCall(
+        name="repair.review",
+        arguments={
+            "validation": validation.data["validation"],
+            "summary": "Calculator repair validated by targeted pytest.",
+        },
+        id="review_e2e",
     )
+    review = registry.execute(review_call, _approved_context(memory, tmp_path, review_call))
     assert review.success
     assert review.data["commit_gate"]["commit_allowed"] is True
     assert review.data["commit_gate"]["approval_required_before_commit"] is True
@@ -1533,13 +1532,12 @@ def test_stale_repair_review_blocks_commit_and_rollback_preserves_artifact(tmp_p
         "command": ["pytest", "-q"],
         "content": "passed",
     }
-    review = registry.execute(
-        ToolCall(
-            name="repair.review",
-            arguments={"validation": validation, "summary": "Calculator fix reviewed."},
-        ),
-        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    review_call = ToolCall(
+        name="repair.review",
+        arguments={"validation": validation, "summary": "Calculator fix reviewed."},
+        id="review_stale",
     )
+    review = registry.execute(review_call, _approved_context(memory, tmp_path, review_call))
     assert review.success
 
     (tmp_path / "calculator.py").write_text("def add(a, b):\n    return a + b + 1\n")
@@ -1598,11 +1596,10 @@ def test_repair_review_creates_commit_gate_after_successful_validation(tmp_path:
             "validation": {"success": True, "command": ["pytest", "-q"], "content": "passed"},
             "summary": "README patch validated with tests.",
         },
+        id="review_gate",
     )
 
-    result = registry.execute(
-        call, ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path)
-    )
+    result = registry.execute(call, _approved_context(memory, tmp_path, call))
 
     assert result.success
     assert result.data["commit_gate"]["commit_allowed"] is True
@@ -1673,16 +1670,15 @@ def test_git_commit_allows_repair_branch_with_current_reviewer_gate(tmp_path: Pa
     )
     memory = build_memory_system("memory", tmp_path / "memory")
     registry = build_default_tools()
-    review = registry.execute(
-        ToolCall(
-            name="repair.review",
-            arguments={
-                "validation": {"success": True, "command": ["pytest", "-q"]},
-                "summary": "validated",
-            },
-        ),
-        ToolContext(memory=memory, config=AgentConfig(), workspace=tmp_path),
+    review_call = ToolCall(
+        name="repair.review",
+        arguments={
+            "validation": {"success": True, "command": ["pytest", "-q"]},
+            "summary": "validated",
+        },
+        id="review_for_commit",
     )
+    review = registry.execute(review_call, _approved_context(memory, tmp_path, review_call))
     call = ToolCall(
         name="git.commit",
         arguments={"message": "repair commit", "repair_review_id": review.data["review_id"]},


### PR DESCRIPTION
### Motivation
- Prevent an unapproved filesystem write by `repair.review` that could be exploited via precreated symlinks and attacker-controlled validation payloads. 
- Align `repair.review` with the repository's existing approval and feature-gating model used for other write-capable repair tools. 

### Description
- Require explicit approval for the tool by setting `requires_approval=True` on `RepairReviewTool` in `src/nested_memvid_agent/tools/repair_tools.py` so exact-call approval flow is enforced. 
- Add `"repair.review": "allow_file_write"` to the `_ENABLEMENT_BY_TOOL` mapping in `src/nested_memvid_agent/tools/registry.py` so the tool is disabled unless `AgentConfig.allow_file_write` is enabled. 
- Update repair-review integration tests in `tests/test_tools.py` to invoke `repair.review` via approved contexts with explicit `ToolCall.id` values so tests reflect the new approval requirement. 

### Testing
- Ran targeted repair-related tests with `pytest -q tests/test_tools.py -k 'repair_review or stale_repair_review or repair_branch_with_current_reviewer_gate'` and they passed. 
- Attempted `pytest -q` for the full suite but collection failed in this environment due to missing optional server dependencies (`fastapi`, `pydantic`), so full-suite results are not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3a4217a8832a8a3a703d515e7930)