### PR TITLE
fix: disable Git checkout hooks in repair.prepare

### DIFF
--- a/src/nested_memvid_agent/tools/repair_tools.py
+++ b/src/nested_memvid_agent/tools/repair_tools.py
@@ -103,7 +103,7 @@ class RepairPrepareTool(AgentTool):
                     data={"dirty_status": status.stdout},
                 )
             created = subprocess.run(  # nosec
-                ["git", "switch", "-c", branch],
+                ["git", "-c", "core.hooksPath=/dev/null", "switch", "-c", branch],
                 cwd=context.workspace,
                 capture_output=True,
                 text=True,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -987,6 +987,59 @@ def test_repair_prepare_refuses_dirty_repo_by_default(tmp_path: Path) -> None:
     assert result.error == "dirty_worktree"
 
 
+def test_repair_prepare_disables_git_checkout_hooks(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    hooks_dir = tmp_path / ".githooks"
+    hooks_dir.mkdir()
+    hook = hooks_dir / "post-checkout"
+    marker = tmp_path / "hook-ran.txt"
+    hook.write_text(f"#!/usr/bin/env sh\necho hook-ran > {marker}\n")
+    hook.chmod(0o755)
+    subprocess.run(
+        ["git", "add", ".githooks/post-checkout"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "-m",
+            "add checkout hook",
+        ],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "core.hooksPath", ".githooks"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    memory = build_memory_system("memory", tmp_path / "memory")
+    registry = build_default_tools()
+    call = ToolCall(
+        name="repair.prepare", arguments={"branch": "codex/no-hooks"}, id="repair_no_hooks"
+    )
+
+    result = registry.execute(
+        call,
+        _approved_context(memory, tmp_path, call),
+    )
+
+    assert result.success
+    assert not marker.exists()
+
+
 def test_repair_status_reports_active_repair_branch_and_changed_files(tmp_path: Path) -> None:
     base = _init_git_repo(tmp_path)
     subprocess.run(


### PR DESCRIPTION
### Motivation
- `repair.prepare` previously invoked `git switch -c <branch>` which can run repository-configured checkout hooks (e.g. `post-checkout`), allowing a malicious tracked hook to execute code during an approval-gated action.
- The tool's purpose is branch isolation for repairs, not command execution, so hook execution must be suppressed to avoid elevating a file-write approval into arbitrary code execution.

### Description
- Modified `RepairPrepareTool` to invoke Git with a safe hooks path by running `git -c core.hooksPath=/dev/null switch -c <branch>` to disable repo hooks during the branch creation; see `src/nested_memvid_agent/tools/repair_tools.py`.
- Added a focused regression test `test_repair_prepare_disables_git_checkout_hooks` to `tests/test_tools.py` that configures `core.hooksPath`, installs and commits a `post-checkout` hook, runs `repair.prepare`, and asserts the hook did not run.
- The change preserves the existing `repair.prepare` behavior, approvals, and returned metadata while removing the ability for repo-contained hooks to execute in this code path.

### Testing
- Ran `pytest -q` which failed during collection in this environment due to missing optional dependencies (`fastapi`/`pydantic`) so full test-suite collection could not complete.
- Ran the targeted suite `pytest -q tests/test_tools.py -k repair_prepare` and the repair-related tests (including the new hook-regression) passed.
- The fix is deliberately minimal and focused on preventing hook execution while retaining current tool semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3a5e4e74832a9624b8fbfaac88b1)