### PR TITLE
feat: show repair review state in scheduler UI

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import axe from "axe-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
-import type { Approval, Run, SecretRef, Session, Skill, Tool, TraceEvent } from "./types";
+import type { Approval, Run, SecretRef, Session, Skill, TaskGraph, Tool, TraceEvent } from "./types";
 
 const baseRun: Run = {
   run_id: "run_1",
@@ -64,6 +64,7 @@ let onboardingProfile: Record<string, unknown> | null;
 let eventSources: MockEventSource[];
 let eventId: number;
 let traceTimelines: Record<string, TraceEvent[]>;
+let taskGraphs: Record<string, TaskGraph>;
 
 describe("App", () => {
   beforeEach(() => {
@@ -165,6 +166,7 @@ describe("App", () => {
         }
       ]
     };
+    taskGraphs = {};
     vi.stubGlobal("fetch", vi.fn(fetchMock));
     vi.stubGlobal("EventSource", MockEventSource);
   });
@@ -218,6 +220,98 @@ describe("App", () => {
     expect(screen.getByText("Auto-activations")).toBeInTheDocument();
     expect(screen.getByText("Activations then rolled back"));
     expect(screen.getByText("procedural"));
+  });
+
+  it("surfaces repair patch review validation and rollback state from the task graph", async () => {
+    const repairRun: Run = {
+      ...baseRun,
+      run_id: "run_repair",
+      message: "Repair calculator add",
+      session_id: "session_repair",
+      assistant_message: "Repair ready for review"
+    };
+    runs = [repairRun];
+    sessions = [
+      {
+        session_id: "session_repair",
+        run_count: 1,
+        status_counts: { completed: 1 },
+        latest_run_id: "run_repair",
+        latest_status: "completed",
+        latest_message: "Repair calculator add",
+        created_at: repairRun.created_at,
+        updated_at: repairRun.updated_at
+      }
+    ];
+    sessionRuns = { session_repair: [repairRun] };
+    approvals = [];
+    taskGraphs.run_repair = {
+      tasks: [
+        {
+          task_id: "validate",
+          title: "Validate repair",
+          goal: "Run targeted validation",
+          profile: "worker",
+          status: "completed",
+          approved: true,
+          required_tools: ["repair.validate"],
+          risk: "high",
+          attempt_count: 1,
+          result: {
+            validation: { success: true, command: ["python", "-m", "pytest", "tests/test_calculator.py", "-q"] },
+            next_action: "create_repair_review_before_commit"
+          }
+        },
+        {
+          task_id: "review",
+          title: "Review repair before commit",
+          goal: "Create durable review artifact",
+          profile: "reviewer",
+          status: "completed",
+          approved: true,
+          required_tools: ["repair.review"],
+          risk: "medium",
+          attempt_count: 1,
+          result: {
+            review_id: "review_abc123",
+            diff_hash: "deadbeefcafebabe",
+            changed_files: ["src/calculator.py"],
+            commit_gate: { approval_required_before_commit: true }
+          }
+        },
+        {
+          task_id: "rollback",
+          title: "Rollback stale repair",
+          goal: "Restore tracked repair changes",
+          profile: "worker",
+          status: "ready",
+          approved: false,
+          required_tools: ["repair.rollback"],
+          risk: "high",
+          attempt_count: 0,
+          result: {
+            rollback_id: "rollback_abc123",
+            restored_files: ["src/calculator.py"],
+            artifact_path: ".nest/repair_rollbacks/rollback_abc123.json"
+          }
+        }
+      ],
+      ready_tasks: [],
+      approval_blocked_tasks: [],
+      subagents: []
+    };
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "Ask Kestrel" });
+    fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
+
+    const panel = await screen.findByLabelText("Repair Patch Review");
+    expect(within(panel).getByText("Validation passed: python -m pytest tests/test_calculator.py -q")).toBeInTheDocument();
+    expect(within(panel).getByText("Review gate: review_abc123 · commit approval required")).toBeInTheDocument();
+    expect(within(panel).getByText("Diff deadbeefcafebabe · src/calculator.py")).toBeInTheDocument();
+    expect(within(panel).getByText("Rollback state: ready · rollback_abc123")).toBeInTheDocument();
+    expect(within(panel).getByText("Restores src/calculator.py and preserves .nest/repair_rollbacks/rollback_abc123.json")).toBeInTheDocument();
   });
 
   it("creates a new local thread and sends without manual session, provider, or model fields", async () => {
@@ -989,8 +1083,9 @@ function payloadFor(path: string): unknown {
   if (path === "/api/logs?limit=120") return [];
   if (path === "/api/cognition/lessons?k=20") return { items: [] };
   if (path === "/api/cognition/failures?k=20") return { items: [] };
-  if (path.match(/^\/api\/runs\/run_[a-z0-9]+\/task-graph$/)) {
-    return { tasks: [], ready_tasks: [], approval_blocked_tasks: [], subagents: [] };
+  const graphMatch = path.match(/^\/api\/runs\/(run_[a-z0-9]+)\/task-graph$/);
+  if (graphMatch) {
+    return taskGraphs[graphMatch[1]] ?? { tasks: [], ready_tasks: [], approval_blocked_tasks: [], subagents: [] };
   }
   const traceMatch = path.match(/^\/api\/runs\/([^/]+)\/trace\?limit=700$/);
   if (traceMatch) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1772,6 +1772,7 @@ export function App() {
               <button type="button" disabled={!activeRun} onClick={() => runScheduler("step")}>Step</button>
               <button type="button" disabled={!activeRun} onClick={() => runScheduler("run")}>Run Until Idle</button>
             </div>
+            <RepairPatchReview tasks={taskGraph?.tasks ?? []} />
             <TaskList title="Approval blocked" tasks={taskGraph?.approval_blocked_tasks ?? []} onApprove={approveTask} />
             <TaskList title="Ready" tasks={taskGraph?.ready_tasks ?? []} onApprove={approveTask} />
             <TaskList title="All tasks" tasks={taskGraph?.tasks ?? []} onApprove={approveTask} />
@@ -3099,6 +3100,82 @@ function SetupWizard({
       </section>
     </div>
   );
+}
+
+function RepairPatchReview({ tasks }: { tasks: TaskNode[] }) {
+  const repairTasks = tasks.filter((task) =>
+    (task.required_tools ?? []).some((tool) => tool.startsWith("repair.") || tool === "git.commit")
+  );
+  if (repairTasks.length === 0) return null;
+
+  const validationTask = repairTasks.find((task) => taskUsesTool(task, "repair.validate") || taskUsesTool(task, "repair.orchestrate_validate"));
+  const reviewTask = repairTasks.find((task) => taskUsesTool(task, "repair.review"));
+  const rollbackTask = repairTasks.find((task) => taskUsesTool(task, "repair.rollback"));
+
+  const validationResult = validationTask?.result ?? null;
+  const validation = readRecord(validationResult?.validation);
+  const validationSuccess = validation?.success === true;
+  const validationCommand = formatCommand(validation?.command);
+
+  const reviewResult = reviewTask?.result ?? null;
+  const reviewId = String(reviewResult?.review_id ?? "pending");
+  const diffHash = String(reviewResult?.diff_hash ?? "pending");
+  const changedFiles = asStringArray(reviewResult?.changed_files);
+  const commitGate = readRecord(reviewResult?.commit_gate);
+  const commitApprovalRequired = commitGate?.approval_required_before_commit === true;
+
+  const rollbackResult = rollbackTask?.result ?? null;
+  const rollbackId = String(rollbackResult?.rollback_id ?? "pending");
+  const restoredFiles = asStringArray(rollbackResult?.restored_files);
+  const artifactPath = String(rollbackResult?.artifact_path ?? ".nest/repair_rollbacks");
+
+  return (
+    <section aria-label="Repair Patch Review" className="run-detail repair-review-panel">
+      <div className="run-title">
+        <h3>Repair Patch Review</h3>
+        <StatusBadge value={reviewTask?.status ?? validationTask?.status ?? "pending"} />
+      </div>
+      <p className="muted">Validation, reviewer gate, and rollback evidence for the selected repair DAG.</p>
+      <div className="list compact-list">
+        {validationTask && (
+          <div className="data-row">
+            <strong>{validationSuccess ? "Validation passed" : "Validation pending"}</strong>
+            <InlineMeta items={[validationTask.status, validationTask.risk, validationTask.scheduler_reason]} />
+            <p>{`${validationSuccess ? "Validation passed" : "Validation state"}: ${validationCommand || validationTask.title}`}</p>
+          </div>
+        )}
+        {reviewTask && (
+          <div className="data-row">
+            <strong>Review gate</strong>
+            <InlineMeta items={[reviewTask.status, reviewTask.profile, commitApprovalRequired ? "exact-call commit approval" : "commit gate pending"]} />
+            <p>{`Review gate: ${reviewId} · ${commitApprovalRequired ? "commit approval required" : "commit gate pending"}`}</p>
+            <p>{`Diff ${diffHash} · ${changedFiles.length ? changedFiles.join(", ") : "no changed files recorded"}`}</p>
+          </div>
+        )}
+        {rollbackTask && (
+          <div className="data-row">
+            <strong>Rollback state</strong>
+            <InlineMeta items={[rollbackTask.status, rollbackTask.risk, rollbackTask.approved ? "approved" : "approval required"]} />
+            <p>{`Rollback state: ${rollbackTask.status} · ${rollbackId}`}</p>
+            <p>{`Restores ${restoredFiles.length ? restoredFiles.join(", ") : "recorded repair files"} and preserves ${artifactPath}`}</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function taskUsesTool(task: TaskNode, toolName: string): boolean {
+  return (task.required_tools ?? []).includes(toolName);
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function formatCommand(value: unknown): string {
+  if (Array.isArray(value)) return value.map((part) => String(part)).filter(Boolean).join(" ");
+  return typeof value === "string" ? value : "";
 }
 
 function TaskList({ title, tasks, onApprove }: { title: string; tasks: TaskNode[]; onApprove: (task: TaskNode) => void }) {


### PR DESCRIPTION
## Summary
- add a Repair Patch Review panel to the scheduler UI for repair DAGs
- surface validation command/result, review gate metadata, changed files, and rollback artifact state
- add a focused web regression test with a repair task graph fixture

## Test Plan
- npm run test --prefix web -- --run src/App.test.tsx -t "surfaces repair patch review"
- ruff check scripts src tests
- mypy src
- python -m compileall -q src tests scripts
- python -m pytest -q
- npm run test --prefix web -- --run
- npm run build --prefix web
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- git diff --check