### PR TITLE
feat: prepare repair panel exact-call actions

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -314,6 +314,96 @@ describe("App", () => {
     expect(within(panel).getByText("Restores src/calculator.py and preserves .nest/repair_rollbacks/rollback_abc123.json")).toBeInTheDocument();
   });
 
+  it("prepares exact-call repair commit and rollback tool requests without invoking them", async () => {
+    const fetchSpy = vi.mocked(fetch);
+    const repairRun: Run = {
+      ...baseRun,
+      run_id: "run_repairactions",
+      message: "Repair calculator add",
+      session_id: "session_repair_actions",
+      assistant_message: "Repair ready for exact-call action"
+    };
+    runs = [repairRun];
+    sessions = [
+      {
+        session_id: "session_repair_actions",
+        run_count: 1,
+        status_counts: { completed: 1 },
+        latest_run_id: "run_repairactions",
+        latest_status: "completed",
+        latest_message: "Repair calculator add",
+        created_at: repairRun.created_at,
+        updated_at: repairRun.updated_at
+      }
+    ];
+    sessionRuns = { session_repair_actions: [repairRun] };
+    approvals = [];
+    toolsPayload = [
+      ...toolsPayload,
+      { name: "git.commit", description: "Commit reviewed repair.", risk: "high", requires_approval: true, source: "builtin", capabilities: ["git"], enabled: true, enablement_flag: null },
+      { name: "repair.rollback", description: "Rollback repair.", risk: "high", requires_approval: true, source: "builtin", capabilities: ["safe-repair"], enabled: true, enablement_flag: null }
+    ];
+    taskGraphs.run_repairactions = {
+      tasks: [
+        {
+          task_id: "review",
+          title: "Review repair before commit",
+          goal: "Create durable review artifact",
+          profile: "reviewer",
+          status: "completed",
+          approved: true,
+          required_tools: ["repair.review"],
+          risk: "medium",
+          attempt_count: 1,
+          result: {
+            review_id: "review_action123",
+            diff_hash: "feedfacecafebeef",
+            changed_files: ["src/calculator.py"],
+            commit_gate: { approval_required_before_commit: true }
+          }
+        },
+        {
+          task_id: "rollback",
+          title: "Rollback stale repair",
+          goal: "Restore tracked repair changes",
+          profile: "worker",
+          status: "ready",
+          approved: false,
+          required_tools: ["repair.rollback"],
+          risk: "high",
+          attempt_count: 0,
+          result: {
+            rollback_id: "rollback_action123",
+            restored_files: ["src/calculator.py"],
+            artifact_path: ".nest/repair_rollbacks/rollback_action123.json"
+          }
+        }
+      ],
+      ready_tasks: [],
+      approval_blocked_tasks: [],
+      subagents: []
+    };
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "Ask Kestrel" });
+    fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
+    const panel = await screen.findByLabelText("Repair Patch Review");
+
+    fireEvent.click(within(panel).getByRole("button", { name: /prepare exact-call git.commit/i }));
+    expect(screen.getByLabelText("Tool")).toHaveValue("git.commit");
+    const toolArgsInput = screen.getAllByLabelText("Arguments JSON")[0] as HTMLTextAreaElement;
+    const commitArgs = JSON.parse(toolArgsInput.value);
+    expect(commitArgs).toMatchObject({ repair_review_id: "review_action123" });
+    expect(String(commitArgs.message)).toContain("review_action123");
+
+    fireEvent.click(within(panel).getByRole("button", { name: /prepare exact-call repair.rollback/i }));
+    expect(screen.getByLabelText("Tool")).toHaveValue("repair.rollback");
+    const rollbackArgs = JSON.parse(toolArgsInput.value);
+    expect(rollbackArgs).toMatchObject({ review_id: "review_action123", reason: "Rollback reviewed repair review_action123" });
+    expect(fetchSpy.mock.calls.some(([path, init]) => String(path).includes("/api/tools/") && init?.method === "POST")).toBe(false);
+  });
+
   it("creates a new local thread and sends without manual session, provider, or model fields", async () => {
     const fetchSpy = vi.mocked(fetch);
     render(<App />);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1772,7 +1772,13 @@ export function App() {
               <button type="button" disabled={!activeRun} onClick={() => runScheduler("step")}>Step</button>
               <button type="button" disabled={!activeRun} onClick={() => runScheduler("run")}>Run Until Idle</button>
             </div>
-            <RepairPatchReview tasks={taskGraph?.tasks ?? []} />
+            <RepairPatchReview
+              tasks={taskGraph?.tasks ?? []}
+              onPrepareTool={(name, args) => {
+                setToolName(name);
+                setToolArgs(JSON.stringify(args, null, 2));
+              }}
+            />
             <TaskList title="Approval blocked" tasks={taskGraph?.approval_blocked_tasks ?? []} onApprove={approveTask} />
             <TaskList title="Ready" tasks={taskGraph?.ready_tasks ?? []} onApprove={approveTask} />
             <TaskList title="All tasks" tasks={taskGraph?.tasks ?? []} onApprove={approveTask} />
@@ -3102,7 +3108,13 @@ function SetupWizard({
   );
 }
 
-function RepairPatchReview({ tasks }: { tasks: TaskNode[] }) {
+function RepairPatchReview({
+  tasks,
+  onPrepareTool
+}: {
+  tasks: TaskNode[];
+  onPrepareTool: (name: string, args: Record<string, unknown>) => void;
+}) {
   const repairTasks = tasks.filter((task) =>
     (task.required_tools ?? []).some((tool) => tool.startsWith("repair.") || tool === "git.commit")
   );
@@ -3128,6 +3140,19 @@ function RepairPatchReview({ tasks }: { tasks: TaskNode[] }) {
   const rollbackId = String(rollbackResult?.rollback_id ?? "pending");
   const restoredFiles = asStringArray(rollbackResult?.restored_files);
   const artifactPath = String(rollbackResult?.artifact_path ?? ".nest/repair_rollbacks");
+  const hasReviewArtifact = reviewId !== "pending";
+  const prepareCommit = () => {
+    onPrepareTool("git.commit", {
+      message: `repair: commit reviewed changes for ${reviewId}`,
+      repair_review_id: reviewId
+    });
+  };
+  const prepareRollback = () => {
+    onPrepareTool("repair.rollback", {
+      reason: `Rollback reviewed repair ${reviewId}`,
+      review_id: reviewId
+    });
+  };
 
   return (
     <section aria-label="Repair Patch Review" className="run-detail repair-review-panel">
@@ -3150,6 +3175,9 @@ function RepairPatchReview({ tasks }: { tasks: TaskNode[] }) {
             <InlineMeta items={[reviewTask.status, reviewTask.profile, commitApprovalRequired ? "exact-call commit approval" : "commit gate pending"]} />
             <p>{`Review gate: ${reviewId} · ${commitApprovalRequired ? "commit approval required" : "commit gate pending"}`}</p>
             <p>{`Diff ${diffHash} · ${changedFiles.length ? changedFiles.join(", ") : "no changed files recorded"}`}</p>
+            <button type="button" className="btn subtle" disabled={!hasReviewArtifact} onClick={prepareCommit}>
+              Prepare exact-call git.commit request
+            </button>
           </div>
         )}
         {rollbackTask && (
@@ -3158,6 +3186,9 @@ function RepairPatchReview({ tasks }: { tasks: TaskNode[] }) {
             <InlineMeta items={[rollbackTask.status, rollbackTask.risk, rollbackTask.approved ? "approved" : "approval required"]} />
             <p>{`Rollback state: ${rollbackTask.status} · ${rollbackId}`}</p>
             <p>{`Restores ${restoredFiles.length ? restoredFiles.join(", ") : "recorded repair files"} and preserves ${artifactPath}`}</p>
+            <button type="button" className="btn subtle" disabled={!hasReviewArtifact} onClick={prepareRollback}>
+              Prepare exact-call repair.rollback request
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Adds repair panel buttons that prepare exact-call git.commit and repair.rollback requests from durable review evidence
- Populates the existing tool invocation form instead of invoking tools directly, preserving approval semantics
- Covers the action affordances with a web regression test that proves no tool POST occurs during preparation

## Test Plan
- npm run test --prefix web -- --run App.test.tsx -t "prepares exact-call repair commit"
- npm run test --prefix web -- --run
- python -m compileall -q src tests scripts && python -m pytest -q
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- npm run build --prefix web