### PR TITLE
test: prove repair rollback approval card exact args

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -497,6 +497,107 @@ describe("App", () => {
     expect(within(approvalCard).getByText(new RegExp(String(preparedArgs.message)))).toBeInTheDocument();
   });
 
+  it("submits a prepared repair rollback request into a pending approval card with exact arguments", async () => {
+    const fetchSpy = vi.mocked(fetch);
+    const repairRun: Run = {
+      ...baseRun,
+      run_id: "run_rollbackapproval",
+      session_id: "session_rollback_approval",
+      message: "Rollback stale repair",
+      assistant_message: "Reviewed repair can be rolled back.",
+      status: "blocked",
+      stop_reason: "tool_approval_required",
+      created_at: "2026-05-16T00:25:00Z",
+      updated_at: "2026-05-16T00:25:00Z"
+    };
+    sessions = [
+      {
+        session_id: "session_rollback_approval",
+        run_count: 1,
+        status_counts: { blocked: 1 },
+        latest_run_id: "run_rollbackapproval",
+        latest_status: "blocked",
+        latest_message: "Rollback stale repair",
+        created_at: repairRun.created_at,
+        updated_at: repairRun.updated_at
+      }
+    ];
+    sessionRuns = { session_rollback_approval: [repairRun] };
+    runs = [repairRun];
+    approvals = [];
+    toolsPayload = [
+      ...toolsPayload,
+      { name: "repair.rollback", description: "Rollback repair.", risk: "high", requires_approval: true, source: "builtin", capabilities: ["safe-repair"], enabled: true, enablement_flag: null }
+    ];
+    taskGraphs.run_rollbackapproval = {
+      tasks: [
+        {
+          task_id: "review",
+          title: "Review repair before rollback",
+          goal: "Confirm durable repair review artifact",
+          profile: "reviewer",
+          status: "completed",
+          approved: true,
+          required_tools: ["repair.review"],
+          risk: "medium",
+          attempt_count: 1,
+          result: {
+            review_id: "review_rollback123",
+            diff_hash: "feedfacecafebeef",
+            changed_files: ["src/calculator.py"],
+            commit_gate: { approval_required_before_commit: true }
+          }
+        },
+        {
+          task_id: "rollback",
+          title: "Rollback stale repair",
+          goal: "Restore tracked repair changes",
+          profile: "worker",
+          status: "ready",
+          approved: false,
+          required_tools: ["repair.rollback"],
+          risk: "high",
+          attempt_count: 0,
+          result: {
+            rollback_id: "rollback_approval123",
+            restored_files: ["src/calculator.py"],
+            artifact_path: ".nest/repair_rollbacks/rollback_approval123.json"
+          }
+        }
+      ],
+      ready_tasks: [],
+      approval_blocked_tasks: [],
+      subagents: []
+    };
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "Ask Kestrel" });
+    fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
+    const panel = await screen.findByLabelText("Repair Patch Review");
+    fireEvent.click(within(panel).getByRole("button", { name: /prepare exact-call repair.rollback/i }));
+    const preparedArgs = JSON.parse((screen.getAllByLabelText("Arguments JSON")[0] as HTMLTextAreaElement).value);
+
+    fireEvent.click(screen.getByRole("button", { name: /invoke tool/i }));
+
+    await waitFor(() => {
+      const invokeCall = fetchSpy.mock.calls.find(
+        ([path, init]) => path === "/api/tools/repair.rollback/invoke" && init?.method === "POST"
+      );
+      expect(invokeCall).toBeDefined();
+      expect(JSON.parse(String(invokeCall?.[1]?.body ?? "{}"))).toMatchObject({
+        run_id: "run_rollbackapproval",
+        session_id: "session_rollback_approval",
+        arguments: preparedArgs
+      });
+    });
+    const approvalCard = await screen.findByRole("group", { name: /approval for repair.rollback/i });
+    expect(within(approvalCard).getByText("repair.rollback")).toBeInTheDocument();
+    expect(within(approvalCard).getByText(/High risk/i)).toBeInTheDocument();
+    expect(within(approvalCard).getByText(/review_rollback123/)).toBeInTheDocument();
+    expect(within(approvalCard).getByText(new RegExp(String(preparedArgs.reason)))).toBeInTheDocument();
+  });
+
   it("creates a new local thread and sends without manual session, provider, or model fields", async () => {
     const fetchSpy = vi.mocked(fetch);
     render(<App />);
@@ -997,6 +1098,31 @@ async function fetchMock(input: RequestInfo | URL, init?: RequestInit): Promise<
       tool_call_id: approval.tool_call_id,
       success: false,
       content: "Approval required for git.commit.",
+      data: { approval_id: approval.approval_id, status: "pending" },
+      error: "approval_required"
+    });
+  }
+  if (path === "/api/tools/repair.rollback/invoke" && init?.method === "POST") {
+    const body = JSON.parse(String(init.body ?? "{}"));
+    const approval: Approval = {
+      approval_id: "approval_repair_rollback",
+      run_id: body.run_id,
+      tool_call_id: "tool_repair_rollback",
+      tool_name: "repair.rollback",
+      arguments: body.arguments,
+      risk: "high",
+      status: "pending",
+      decision: null,
+      result: null,
+      created_at: "2026-05-16T00:26:00Z",
+      updated_at: "2026-05-16T00:26:00Z"
+    };
+    approvals = [approval];
+    return jsonResponse({
+      tool: "repair.rollback",
+      tool_call_id: approval.tool_call_id,
+      success: false,
+      content: "Approval required for repair.rollback.",
       data: { approval_id: approval.approval_id, status: "pending" },
       error: "approval_required"
     });


### PR DESCRIPTION
## Summary
- add a repair UI regression for prepared exact-call repair.rollback requests
- prove the Connected Tools invoke payload preserves active run/session and exact rollback args
- mock approval_required and assert the pending approval card preserves review_id and rollback reason

## Test Plan
- npm run test --prefix web -- --run App.test.tsx -t "prepared repair rollback request"
- npm run test --prefix web -- --run
- python -m compileall -q src tests scripts && python -m pytest -q
- python scripts/run_golden_evals.py --backend memory --provider mock
- PYTHONPATH=src python -m nested_memvid_agent.cli chat --backend memory --provider mock --message "hello"
- npm run build --prefix web
- git diff --check && git diff --stat